### PR TITLE
fix datetime filter for proper Jinja rendering

### DIFF
--- a/src/render_engine/engine.py
+++ b/src/render_engine/engine.py
@@ -1,5 +1,4 @@
 import urllib.parse
-
 from datetime import datetime
 from email import utils
 
@@ -37,11 +36,15 @@ engine.filters["to_pub_date"] = to_pub_date
 
 
 @pass_environment
-def format_datetime(env: Environment, value: str) -> str:
+def format_datetime(env: Environment, value: str, datetime_format: str) -> str:
     """
     Parse information from the given class object.
     """
-    return datetime.strftime(value, env.globals.get("DATETIME_FORMAT", "%d %b %Y %H:%M %Z"))
+    if datetime_format:
+        format = datetime_format
+    else:
+        format = env.globals.get("DATETIME_FORMAT", "%d %b %Y %H:%M %Z")
+    return datetime.strftime(value, format)
 engine.filters["format_datetime"] = format_datetime
 
 
@@ -71,7 +74,7 @@ def url_for(env: Environment, value: str, page: int=0) -> str:
                 if getattr(page, page._reference) == route:
                     return page.url_for()
 
-    else: 
+    else:
         route = routes.get(value)
         if isinstance(route, Collection):
             return list(route.archives)[page].url_for()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,25 @@
+import pytest
+import jinja2
+import datetime
+from render_engine.engine import format_datetime
+
+
+@pytest.mark.parametrize(
+    "format, override, expected",
+    [{"DATETIME_FORMAT": "%B %d %Y %H:%M"}, None, "September 27 2023 14:00"], # Test given value in jinja global
+    [{}, None, "27 Sep 2023 14:00 UTC"], # Test default if no global set
+    [{"DATETIME_FORMAT": "%B %d %Y %H:%M"}, "%B %d %Y", "September 27 2023"], # Test override
+    )
+)
+def test_format_datetime(format, override, expected):
+    """
+    Tests that the datetime filter works with the following format:
+    
+    """
+    env = jinja2.Environment()
+    env.globals.update(format)
+    format_datetime(
+        env,
+        datetime.datetime(2023, 9, 27, 14, 0, 0),
+        override=override,
+    )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -6,9 +6,10 @@ from render_engine.engine import format_datetime
 
 @pytest.mark.parametrize(
     "format, override, expected",
-    [{"DATETIME_FORMAT": "%B %d %Y %H:%M"}, None, "September 27 2023 14:00"], # Test given value in jinja global
-    [{}, None, "27 Sep 2023 14:00 UTC"], # Test default if no global set
-    [{"DATETIME_FORMAT": "%B %d %Y %H:%M"}, "%B %d %Y", "September 27 2023"], # Test override
+    (
+        ({"DATETIME_FORMAT": "%B %d %Y %H:%M"}, None, "September 27 2023 14:00"), # Test given value in jinja global
+        ({}, None, "27 Sep 2023 14:00 UTC"), # Test default if no global set
+        ({"DATETIME_FORMAT": "%B %d %Y %H:%M"}, "%B %d %Y", "September 27 2023"), # Test override
     )
 )
 def test_format_datetime(format, override, expected):
@@ -19,7 +20,7 @@ def test_format_datetime(format, override, expected):
     env = jinja2.Environment()
     env.globals.update(format)
     format_datetime(
-        env,
-        datetime.datetime(2023, 9, 27, 14, 0, 0),
-        override=override,
+        env=env,
+        value=datetime.datetime(2023, 9, 27, 14, 0, 0),
+        datetime_format=override,
     )


### PR DESCRIPTION
## Summary

Fixing the format_datetime to accept user input, and if found, render it instead of the site default.

## Type of Issue

- [ x ] :bug: (bug)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)

## Issues Referenced

resolves #253


