### PR TITLE
Rename-collection_vars

### DIFF
--- a/docs/docs/collection.md
+++ b/docs/docs/collection.md
@@ -1,1 +1,7 @@
 ::: src.render_engine.collection.Collection
+
+# Passing Collection Variables to a Rendered Page
+
+You can access attributes from the `Collection` class inside all of its rendered pages.
+
+Each `Page` in a collection has a `collection` attribute, with a dictionary of key:value pairs similar to `Page.template_vars`. The dictionary includes any additional attributes you have defined within the `Collection` class.

--- a/docs/docs/getting-started/creating-a-collection.md
+++ b/docs/docs/getting-started/creating-a-collection.md
@@ -43,6 +43,11 @@ I'm a scientist. I'm also a superhero.
 
 The collection would have all the information to parse all its pages the same. These could be attributes like the `template` or the `PageParser` that is used to parse each page in the collection. The individual pages attributes can  be referenced in the template or used for sorting or other functions.
 
+If you want to pass additional objects through the template context (see [Jinja's Template Context](https://jinja.palletsprojects.com/en/3.0.x/api/#the-context)), you can create additional attributes.
+
+For example, if you want to send an attribute called `some_value` with a value of `"42"`, you can create this attribute in your `Collection` class, and it will be passed to the template through a `collection` attribute that contains a key:value pair (`{"some_value: "42"}`).
+
+
 ```python
 
 # app.py
@@ -57,6 +62,8 @@ class Heroes(Collection):
   content_path = "content/heroes"
   template = "heroes.html"
   PageParser = `MarkdownPageParser`
+  some_value = "42"
+  }
 ```
 
 [Collection]: ../collection

--- a/src/render_engine/collection.py
+++ b/src/render_engine/collection.py
@@ -8,7 +8,6 @@ from slugify import slugify
 from ._base_object import BaseObject
 from .archive import Archive
 from .feeds import RSSFeed
-from .hookspecs import register_plugins
 from .page import Page
 from .parsers import BasePageParser
 from .parsers.markdown import MarkdownPageParser
@@ -81,7 +80,7 @@ class Collection(BaseObject):
             ]
         )
         self.title = self._title
-        
+
     def iter_content_path(self):
         """Iterate through in the collection's content path."""
 
@@ -91,20 +90,20 @@ class Collection(BaseObject):
                 for suffix in self.include_suffixes
             ]
         )
-    
+
     def _generate_content_from_modified_pages(self) -> typing.Generator[Page, None, None]:
         """
         Check git status for newly created and modified files.
         Returns the Page objects for the files in the content path
         """
-        
+
         repo = git.Repo()
-        
+
         changed_files = [
             *repo.untracked_files, # new files not yet in git's index
             *repo.index.diff(), # modified files in git index
         ]
-        
+
         return (
             self.get_page(pathlib.Path(changed_path))
             for changed_path in changed_files
@@ -126,7 +125,7 @@ class Collection(BaseObject):
         _page.parser_extras = getattr(self, "parser_extras", {})
         _page.routes = self.routes
         _page.template = getattr(self, "template", None)
-        _page.collection_vars = self.to_dict()
+        _page.collection = self.to_dict()
         return _page
 
     @property

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -68,9 +68,9 @@ def test_collection_archive_no_items_per_page(tmp_path: pathlib.Path):
     assert len(list(collection.archives)) == 1
 
 
-def test_collection_vars(tmp_path: pathlib.Path):
+def test_collection_context(tmp_path: pathlib.Path):
     """
-    Tests that collection_vars are passed to the page objects
+    Tests that `collection` context is passed to the page objects
     """
 
     tmp_dir = tmp_path / "content"
@@ -85,7 +85,7 @@ def test_collection_vars(tmp_path: pathlib.Path):
     collection = BasicCollection()
 
     for page in collection:
-        assert page.collection_vars["title"] == collection._title
+        assert page.collection["title"] == collection._title
 
 
 def test_collection_archives_has_title_of_collection(tmp_path: pathlib.Path):
@@ -144,7 +144,7 @@ def test_collection_attrs_pass_to_page(tmp_path, attr: str, attrval: str | list[
     class BasicCollection(Collection):
         PageParser = SimpleBasePageParser
         content_type = Page
-        
+
     setattr(BasicCollection, attr, attrval)
 
     collection = BasicCollection()


### PR DESCRIPTION
## Summary

Changing name of `collection_vars` to `collection`. Also updated documentation to reference this.

## Type of Issue

Change attribute name

## Issues Referenced

resolves #259


