### PR TITLE
🛠️ [FIX] render_engine_hook-in-render_output in one location

### DIFF
--- a/src/render_engine/page.py
+++ b/src/render_engine/page.py
@@ -149,7 +149,6 @@ class Page(BasePage):
         if Parser:
             self.Parser = Parser
 
-        print(getattr(self, "content", None))
         # Parse Content from the Content Path or the Content
         if content_path := (content_path or getattr(self, "content_path", None)):
             attrs, self.content = self.Parser.parse_content_path(content_path)

--- a/src/render_engine/page.py
+++ b/src/render_engine/page.py
@@ -32,6 +32,7 @@ class BasePage(BaseObject):
     @property
     def _content(self):
         """Returns the content of the page."""
+        print(getattr(self, "content", None))
         return getattr(self, "content", None)
 
     def url_for(self) -> str:

--- a/src/render_engine/page.py
+++ b/src/render_engine/page.py
@@ -32,7 +32,6 @@ class BasePage(BaseObject):
     @property
     def _content(self):
         """Returns the content of the page."""
-        print(getattr(self, "content", None))
         return getattr(self, "content", None)
 
     def url_for(self) -> str:
@@ -77,6 +76,7 @@ class BasePage(BaseObject):
 
         # Parsing without a template
         try:
+            print(self._content)
             if isinstance(self._content, str):
                 return self._content
             

--- a/src/render_engine/page.py
+++ b/src/render_engine/page.py
@@ -76,7 +76,7 @@ class BasePage(BaseObject):
 
         # Parsing without a template
         try:
-            print(self._content)
+            print(self.content)
             if isinstance(self._content, str):
                 return self._content
             

--- a/src/render_engine/page.py
+++ b/src/render_engine/page.py
@@ -76,7 +76,6 @@ class BasePage(BaseObject):
 
         # Parsing without a template
         try:
-            print(self.content)
             if isinstance(self._content, str):
                 return self._content
             
@@ -150,6 +149,7 @@ class Page(BasePage):
         if Parser:
             self.Parser = Parser
 
+        print(getattr(self, "content", None))
         # Parse Content from the Content Path or the Content
         if content_path := (content_path or getattr(self, "content_path", None)):
             attrs, self.content = self.Parser.parse_content_path(content_path)

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -183,6 +183,7 @@ class Site(ThemeManager):
             / pathlib.Path(page.path_name)
         )
         path.parent.mkdir(parents=True, exist_ok=True)
+        self._pm.hook.render_content(page=page.__class__, settings=settings, site=self)
         page.rendered_content = page._render_content(engine=self.engine)
         # pass the route to the plugin settings
         settings = {**self.site_settings.get('plugins', {}), **{'route': route}}

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -173,8 +173,6 @@ class Site(ThemeManager):
 
         self.route_list[getattr(page, page._reference)] = page
 
-
-
     def _render_output(self, route: str, page: Page):
         """writes the page object to disk"""
         path = (
@@ -183,10 +181,10 @@ class Site(ThemeManager):
             / pathlib.Path(page.path_name)
         )
         path.parent.mkdir(parents=True, exist_ok=True)
+        settings = {**self.site_settings.get('plugins', {}), **{'route': route}}
         self._pm.hook.render_content(page=page.__class__, settings=settings, site=self)
         page.rendered_content = page._render_content(engine=self.engine)
         # pass the route to the plugin settings
-        settings = {**self.site_settings.get('plugins', {}), **{'route': route}}
         self._pm.hook.post_render_content(page=page.__class__, settings=settings, site=self)
 
         return path.write_text(page.rendered_content)

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -182,7 +182,7 @@ class Site(ThemeManager):
         )
         path.parent.mkdir(parents=True, exist_ok=True)
         settings = {**self.site_settings.get('plugins', {}), **{'route': route}}
-        self._pm.hook.render_content(page=page.__class__, settings=settings, site=self)
+        self._pm.hook.render_content(page=page, settings=settings, site=self)
         page.rendered_content = page._render_content(engine=self.engine)
         # pass the route to the plugin settings
         self._pm.hook.post_render_content(page=page.__class__, settings=settings, site=self)

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -208,7 +208,6 @@ class Site(ThemeManager):
         """Iterate through Pages and Check for Collections and Feeds"""
 
         for entry in collection:
-            self._pm.hook.render_content(page=entry)
             for route in collection.routes:
                 self._render_output(route, entry)
 

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -182,7 +182,7 @@ class Site(ThemeManager):
         )
         path.parent.mkdir(parents=True, exist_ok=True)
         settings = {**self.site_settings.get('plugins', {}), **{'route': route}}
-        self._pm.hook.render_content(page=page, settings=settings, site=self)
+        self._pm.hook.render_content(page=page, settings=settings)
         page.rendered_content = page._render_content(engine=self.engine)
         # pass the route to the plugin settings
         self._pm.hook.post_render_content(page=page.__class__, settings=settings, site=self)

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -139,10 +139,8 @@ def test_collection_archive_in_route_list(tmp_path):
         has_archive = True
         pages = [CustomCollectionPage()]
 
-    print(site.route_list)
 
     site.render()
-    print(list(tmp_path.iterdir()))
     assert pathlib.Path(tmp_path / "customcollection.html").exists()
     assert pathlib.Path(tmp_path / "customcollectionpage.html").exists()
     assert pathlib.Path(tmp_path / "customcollection.html").read_text() == "This is the collection archive"


### PR DESCRIPTION
## Summary

now `render_content` and `post_render_content` only run in `site._render_output`

## Type of Issue

- [X] :bug: (bug)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)

## Issues Referenced

resolves <#ISSUE NUMBER>

## Discussions Referenced

address <#DISCUSSION NUMBER>

## Next Steps

Lots of documenation around how plugins work (for both users and developers)

<ANY FURTHER STEPS TO BE TAKEN>
