### PR TITLE
Kjaymiller/issue267

### DIFF
--- a/docs/docs/getting-started/creating-a-collection.md
+++ b/docs/docs/getting-started/creating-a-collection.md
@@ -69,5 +69,7 @@ class Heroes(Collection):
 
 The value of `42` can be accessed in your template using `{{collection.some_value}}`.
 
+### Continue to [Simple Site Layout](../simple-site-layout/)
+
 [Collection]: ../collection
 [Creating a Page]: /getting-started/creating-a-page

--- a/docs/docs/getting-started/creating-a-page.md
+++ b/docs/docs/getting-started/creating-a-page.md
@@ -79,5 +79,7 @@ class About(Page):
 
 ```
 
+### Continue to [Creating a Collection](../creating-a-collection/)
+
 [Jinja2]: https://palletsprojects.com/p/jinja/
 [Parser]: ../parsers

--- a/docs/docs/getting-started/creating-your-app.md
+++ b/docs/docs/getting-started/creating-your-app.md
@@ -20,3 +20,5 @@ You can view the options using the `--help` flag.
 ![render-engine init --help](../assets/render-engine-init-help.png)
 
 Visit the [CLI - init](../cli/init.md) page for more information.
+
+### Continue to [Creating a Page](../creating-a-page/)

--- a/docs/docs/getting-started/getting-started.md
+++ b/docs/docs/getting-started/getting-started.md
@@ -1,12 +1,16 @@
 # Getting Started
 
-- [Installation](../installation.md)
-- [Creating your app]](../simple-site-layout.md)
-- [Building your Site](../building-your-site.md)creating-your-app.md)
-- [Creating a Page](../creating-a-page.md)
-- [Creating a Collection](../creating-a-collection.md)
-- [Simple Site Layout
-](../simple-site-layout.md)
-- [Building your Site](../building-your-site.md)
+This section will walk you through the basics of Render Engine. It will show you how to create a simple site and how to add pages and collections to your site.
+
+### Sections
+#### [Installation](../installation.md)
+#### [Creating your app](../creating-your-app.md)
+#### [Building your Site](../building-your-site.md)
+#### [Creating a Page](../creating-a-page.md)
+#### [Creating a Collection](../creating-a-collection.md)
+#### [Simple Site Layout](../simple-site-layout.md)
+#### [Building your Site](../building-your-site.md)
+
+---
 
 ### Continue to [Installation](../installation.md)

--- a/docs/docs/getting-started/getting-started.md
+++ b/docs/docs/getting-started/getting-started.md
@@ -1,0 +1,12 @@
+# Getting Started
+
+- [Installation](../installation.md)
+- [Creating your app]](../simple-site-layout.md)
+- [Building your Site](../building-your-site.md)creating-your-app.md)
+- [Creating a Page](../creating-a-page.md)
+- [Creating a Collection](../creating-a-collection.md)
+- [Simple Site Layout
+](../simple-site-layout.md)
+- [Building your Site](../building-your-site.md)
+
+### Continue to [Installation](../installation.md)

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -19,4 +19,6 @@ For example, to use the rss parser, you will need to install the [render-engine-
 pip install render-engine render-engine-rss
 ```
 
+### Continue to [Creating Your App](../creating-your-app/)
+
 [render-engine-rss]: https://pypi.org/project/render-engine-rss/

--- a/docs/docs/getting-started/layout.md
+++ b/docs/docs/getting-started/layout.md
@@ -221,7 +221,7 @@ You an also pass custom attributes to the collection. These attributes will be p
 
 #### Custom Collections
 
-We named our collection Blog but if you noticed there aren't a lot of features that come with a blog included. Render Engine has a built in `Blog` class that you can use to create a blog. It will automatically create a collection of posts and a page for each post. It will also create a page for the blog index and an RSS Feed.
+We named our collection Blog but there aren't a lot of features that come with a blog included. Render Engine actually has a built-in `Blog` class you can use to create a blog. It will automatically create a collection of posts and a page for each post. It will also create a page for the blog index and an RSS Feed.
 
 It's still rendered using the same `render_collection` decorator.
 

--- a/docs/docs/getting-started/layout.md
+++ b/docs/docs/getting-started/layout.md
@@ -233,3 +233,5 @@ class Blog(Blog):
   template="blog.html"
   content_path="content/blog"
 ```
+
+### Continue to [Building Your Site](../building-your-site/)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -19,4 +19,4 @@ pip install render-engine
 ```
 
 ## Getting Started
-Check out the [Getting Started](/getting-started/).
+Check out the [Getting Started](/getting-started/installation).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -19,4 +19,4 @@ pip install render-engine
 ```
 
 ## Getting Started
-Check out the [Getting Started](/getting-started/installation).
+Check out the [Getting Started](/getting-started/getting-started).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -5,6 +5,7 @@ theme:
 nav:
   - Home: index.md
   - Getting Started:
+    - getting-started/getting-started.md
     - getting-started/installation.md
     - getting-started/creating-your-app.md
     - getting-started/creating-a-page.md


### PR DESCRIPTION
## Summary

Changes the "getting started" link on the homepage to a _Getting Started_ page that has a brief description and links to all the sections. 

Each page in the getting started section now links to the next page in the getting started.

Shout out to @lauralangdon and @mannyanebi for pointing out the issue!

## Type of Issue

- [ ] :bug: (bug)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [X] :book: Documentation

## Issues Referenced

resolves #267

## Discussions Referenced

address <#DISCUSSION NUMBER>

## Next Steps

Continue to improve docs
