### PR TITLE
make link reference parent

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -19,4 +19,4 @@ pip install render-engine
 ```
 
 ## Getting Started
-Check out the [Getting Started](/getting-started/getting-started).
+Check out the [Getting Started](../getting-started/getting-started).


### PR DESCRIPTION
## Summary

Minor patch to #278. Locally the PR worked but url in prod was removing a part of the url required by readthedocs.

## Type of Issue

- [ ] :bug: (bug)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [X] :book: (Documentation)

## Issues Referenced

#267

## Discussions Referenced

address <#DISCUSSION NUMBER>

## Next Steps

Update docs and issues