### PR TITLE
hard_code default template for archive

### DIFF
--- a/docs/docs/archive.md
+++ b/docs/docs/archive.md
@@ -8,6 +8,18 @@ Archive objects create a customizeable page that can be controlled via its paren
 
 Collection.archives yields a generator of Archive objects. Each Archive object will have a `pages` attribute that is a list of Page objects referenced in that Archive Page. The number of pages is determined by the `Collection.items_per_page` attribute.
 
-The slug of the Archive Page is determined by whether the Archive is paginated.
+## Enabling Archive Pages
 
-If there is more than one archive page, the Archive.archive_index will be appended to the Archive.slug . For example, if the Archive.slug is `archive` and the Archive.archive_index is `2`, the Archive Page will have a slug of `archive2`.
+By default render engine will only create the archive page is either of the following conditions are met:
+
+- The `Collection.items_per_page` attribute is set to a value greater than 0.
+- The `Collection.has_archive` attribute is set to True.
+
+
+## Archive Page Numbers
+
+Archive pages are numbered starting at `0`. **The first page is always a list containing all the items.**
+
+If `items_per_page` is greater than `0`, the remaining will contain the items in the collection, split into groups of `items_per_page`.
+
+You can get the total number of `Archive` pages by grabbing the `Archive.num_archive_pages` attribute.

--- a/docs/docs/collection.md
+++ b/docs/docs/collection.md
@@ -27,3 +27,9 @@ You can access `some_value` in your template like this:
 ```
 {{collection.some_value}}
 ```
+
+## Collection Archives
+
+Collection archives are a special type of page that is automatically generated for each collection.
+
+For more information, see [Collection Archives](/docs/archive).

--- a/src/render_engine/collection.py
+++ b/src/render_engine/collection.py
@@ -54,7 +54,7 @@ class Collection(BaseObject):
 
     """
 
-    archive_template: str | None
+    archive_template: str|pathlib.Path = "archive.html"
     content_path: pathlib.Path | str
     content_type: Page = Page
     Feed: RSSFeed
@@ -73,12 +73,9 @@ class Collection(BaseObject):
         self,
     ) -> None:
 
-        self.has_archive = any(
-            [
-                hasattr(self, "archive_template"),
-                getattr(self, "items_per_page", None),
-            ]
-        )
+        if not getattr(self, 'has_archive', False):
+            self.has_archive = getattr(self, "items_per_page", None)
+
         self.title = self._title
 
     def iter_content_path(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ def site(tmp_path):
     class TestCollection(Collection):
         pages = [Page(content_path=file)]
         Feed = RSSFeed
+        has_archive = True
 
     return site
 


### PR DESCRIPTION
## Summary

### `has_archive` is now a changeable attribute for the default `Collection` object.

You can set enabled an Archive by setting `has_archive` to `True`, or setting the `items_per_page` attribute.

### `archive.html` as a default template is also now available

## Type of Issue

- [ ] :bug: (bug)
- [x] :book: (Documentation)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)

## Issues Referenced

resolves <#ISSUE NUMBER>

## Discussions Referenced

address <#DISCUSSION NUMBER>

## Next Steps

<ANY FURTHER STEPS TO BE TAKEN>
