### PR TITLE
make static site optional for themes

### DIFF
--- a/src/render_engine/utils/themes.py
+++ b/src/render_engine/utils/themes.py
@@ -9,8 +9,8 @@ from jinja2 import BaseLoader, Environment
 @dataclasses.dataclass
 class Theme:
     loader: BaseLoader
-    static_dir: str|pathlib.Path
     filters: dict[str, callable]
+    static_dir: str | pathlib.Path | None = None
     plugins: list[callable] | None = None
 
 class ThemeManager:
@@ -39,7 +39,10 @@ class ThemeManager:
         """
         logging.info(f"Registering theme: {theme}")
         self.engine.loader.loaders.insert(0, theme.loader)
-        self.static_paths.add(theme.static_dir)
+        
+        if theme.static_dir:
+            logging.debug(f"Adding static path: {theme.static_dir}")
+            self.static_paths.add(theme.static_dir)
         self.engine.filters.update(theme.filters)
 
     def register_themes(self, *themes: Theme):

--- a/tests/test_theme_manager.py
+++ b/tests/test_theme_manager.py
@@ -1,3 +1,4 @@
+from typing import Dict
 import pytest
 from jinja2.environment import Environment
 from jinja2.loaders import DictLoader, ChoiceLoader
@@ -18,6 +19,7 @@ def test_ThemeManager_builds():
     assert 'test1.html' in thememgr.engine.list_templates()
     assert thememgr.engine.get_or_select_template('test1.html').render() == "This is a test"
 
+
 def test_ThemeManager_registers_theme():
     loader1=DictLoader({"test1.html": "This is a TeSt"})
     loader2=DictLoader({"test2.html": "This is a {{'TeSt'|test_up}}"})
@@ -34,11 +36,16 @@ def test_ThemeManager_registers_theme():
         static_dir="test",
         filters={"test_down": lambda x: x.lower()}
     )
+
+    loader4theme = Theme(
+        loader=loader1,
+        filters = {}
+    )
     class TestThemeManager(ThemeManager):
         engine = Environment(loader=ChoiceLoader(loaders=[loader1]))
 
     thememgr = TestThemeManager()
-    thememgr.register_themes(loader2theme, loader3theme)
+    thememgr.register_themes(loader2theme, loader3theme, loader4theme)
     assert "test2.html" in thememgr.engine.list_templates()
     assert thememgr.engine.get_or_select_template('test2.html').render(test="test") == "This is a TEST"
     assert "test3.html" in thememgr.engine.list_templates()


### PR DESCRIPTION
## Summary

Some themes don't have static paths so the attribute should be optional

## Type of Issue

- [X] :bug: (bug)
- [ ] :book: (Documentation)
- [X] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)

## Issues Referenced

resolves <#ISSUE NUMBER>

## Discussions Referenced

address <#DISCUSSION NUMBER>

## Next Steps

<ANY FURTHER STEPS TO BE TAKEN>
