### PR TITLE
required_themes and removes base.html from copied templates

### DIFF
--- a/docs/docs/custom_collections.md
+++ b/docs/docs/custom_collections.md
@@ -46,6 +46,8 @@ While you can set any of the attributes and override any methods on the Collecti
 
 `parser_extras: dict[str, Any]`: Extra attributes that will be passed to the `PageParser` class.
 
+`required_themes: list[Theme]`: Some collections may require a specific theme to be used. This attribute allows you to set a list of themes that will be required for the collection. These will be installed when @site.collection is called.
+
 `sort_by: str`: The attribute that will be used to sort the collection `Page` objects. By default, this is the title of the page, but you can set this to any attribute that is available on the page object, or leave it to the user to set.
 
 `sort_reverse: bool`: Whether or not the collection should be sorted in reverse order. By default, this is False, but you can set this to True, or leave it to the user to set.

--- a/src/render_engine/cli.py
+++ b/src/render_engine/cli.py
@@ -210,7 +210,7 @@ def init(
         task_templates = progress.add_task(
             f"Creating Templates Folder: [blue]{templates_path}", total=1
         )
-        templates = ["index.html", "base.html", "content.html"]
+        templates = ["index.html", "content.html"]
         _create_templates_folder(
             *templates,
             project_folder=project_folder,

--- a/src/render_engine/collection.py
+++ b/src/render_engine/collection.py
@@ -45,6 +45,7 @@ class Collection(BaseObject):
         items_per_page: int | None
         PageParser: Type[BasePageParser] = MarkdownPageParser
         parser_extras: dict[str, Any]
+        required_themes: list[callable]
         routes: list[str] = ["./"]
         sort_by: str = "title"
         sort_reverse: bool = False
@@ -64,6 +65,7 @@ class Collection(BaseObject):
     items_per_page: int | None
     PageParser: BasePageParser = MarkdownPageParser
     parser_extras: dict[str, any]
+    required_themes: list[typing.Callable]
     routes: list[str] = ["./"]
     sort_by: str = "title"
     sort_reverse: bool = False

--- a/src/render_engine/render_engine_templates/base.html
+++ b/src/render_engine/render_engine_templates/base.html
@@ -1,15 +1,14 @@
-{% raw %}
-    <!DOCTYPE html>
-    <html lang="en">
-        <head>
-            <meta charset="UTF-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <meta http-equiv="X-UA-Compatible" content="ie=edge">
-            <title>{% block title %}Document{% endblock %}</title>
-        </head>
-        <body>
-            {% block content %}
-            {% endblock %}
-        </body>
-    </html>
-{% endraw %}
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="X-UA-Compatible" content="ie=edge">
+        <title>{% block title %}{{SITE_TITLE}}{% endblock %}</title>
+        {% block head %}{% endblock %}
+    </head>
+    <body>
+        {% block content %}
+        {% endblock %}
+    </body>
+</html>

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -123,6 +123,7 @@ class Site(ThemeManager):
         ```
         """
         _Collection = Collection()
+        self.register_themes(_Collection.required_themes)
         plugins = [*self.plugins, *getattr(_Collection, "plugins", [])]
         
         for plugin in getattr(_Collection, 'ignore_plugins', []):

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -123,7 +123,7 @@ class Site(ThemeManager):
         ```
         """
         _Collection = Collection()
-        self.register_themes(*getattr(_Collection, "required_themes", []))
+        self.register_themes(*getattr(_Collection, "required_themes",[]))
         plugins = [*self.plugins, *getattr(_Collection, "plugins", [])]
         
         for plugin in getattr(_Collection, 'ignore_plugins', []):

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -199,6 +199,7 @@ class Site(ThemeManager):
         if getattr(collection, 'has_archive', False):
             for archive in collection.archives:
                 logging.debug("Adding Archive: %s", archive.__class__.__name__)
+                print("Building Partial Archive using template: %s", archive.template)
 
                 self._render_output(collection.routes[0], archive)
 
@@ -215,6 +216,7 @@ class Site(ThemeManager):
         if getattr(collection, 'has_archive', False):
             for archive in collection.archives:
                 logging.debug("Adding Archive: %s", archive.__class__.__name__)
+                print("Building Full Archive using template: %s", archive.template)
 
                 for route in collection.routes:
                     self._render_output(collection.routes[0], archive)
@@ -270,10 +272,11 @@ class Site(ThemeManager):
                         self._render_output(route, entry)
 
                 if isinstance(entry, Collection):
-                    if self.partial:
-                        self._render_partial_collection(entry)
-                    else:
+                    if not self.partial:
                         self._render_full_collection(entry)
+                    else:
+                        self._render_partial_collection(entry)
+
             progress.add_task("Loading Post-Build Plugins", total=1)
             self._pm.hook.post_build_site(
                 site=self,

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -123,7 +123,7 @@ class Site(ThemeManager):
         ```
         """
         _Collection = Collection()
-        self.register_themes(_Collection.required_themes)
+        self.register_themes(*getattr(_Collection, "required_themes", []))
         plugins = [*self.plugins, *getattr(_Collection, "plugins", [])]
         
         for plugin in getattr(_Collection, 'ignore_plugins', []):
@@ -199,7 +199,6 @@ class Site(ThemeManager):
         if getattr(collection, 'has_archive', False):
             for archive in collection.archives:
                 logging.debug("Adding Archive: %s", archive.__class__.__name__)
-                print("Building Partial Archive using template: %s", archive.template)
 
                 self._render_output(collection.routes[0], archive)
 
@@ -216,7 +215,6 @@ class Site(ThemeManager):
         if getattr(collection, 'has_archive', False):
             for archive in collection.archives:
                 logging.debug("Adding Archive: %s", archive.__class__.__name__)
-                print("Building Full Archive using template: %s", archive.template)
 
                 for route in collection.routes:
                     self._render_output(collection.routes[0], archive)

--- a/src/render_engine/utils/themes.py
+++ b/src/render_engine/utils/themes.py
@@ -9,9 +9,9 @@ from jinja2 import BaseLoader, Environment
 @dataclasses.dataclass
 class Theme:
     loader: BaseLoader
-    filters: dict[str, callable]
+    filters: dataclasses.field(default_factory=dict)
+    plugins: dataclasses.field(default_factory=list)
     static_dir: str | pathlib.Path | None = None
-    plugins: list[callable] | None = None
 
 class ThemeManager:
     """

--- a/tests/test_theme_manager.py
+++ b/tests/test_theme_manager.py
@@ -28,18 +28,21 @@ def test_ThemeManager_registers_theme():
     loader2theme = Theme(
         loader=loader2,
         static_dir="test",
-        filters={"test_up": lambda x: x.upper()}
+        filters={"test_up": lambda x: x.upper()},
+        plugins = []
     )
 
     loader3theme = Theme(
         loader=loader3,
         static_dir="test",
-        filters={"test_down": lambda x: x.lower()}
+        filters={"test_down": lambda x: x.lower()},
+        plugins = []
     )
 
     loader4theme = Theme(
         loader=loader1,
-        filters = {}
+        filters = {},
+        plugins = []
     )
     class TestThemeManager(ThemeManager):
         engine = Environment(loader=ChoiceLoader(loaders=[loader1]))


### PR DESCRIPTION
## Summary

Creates required_themes for collection items.

Required themes are used for custom collections to ensure that the required theme templates are installed.

The other change was to create simple expandability for custom themes and that was to remove the copying of the `base.html` theme from the quickstart.

In practice none of the template files need to be included  as they are already loaded but these were being exported using the `{%raw%}` expression. This was causing custom templates to not inherit from them properly.

If we were going to add the `base.html` back (as a placeholder to be customized) - the template files should be separated and copied separately.
## Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [X] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [x] :no_entry_sign: (Removal)

## Issues Referenced

resolves <#ISSUE NUMBER>

## Discussions Referenced

address <#DISCUSSION NUMBER>

## Next Steps

<ANY FURTHER STEPS TO BE TAKEN>
