### PR TITLE
Add minimum python requirement to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "render_engine"
 dynamic = ["version"]
 description = "A Flexible Static Site Generator for Python"
 readme = "README.md"
-
+python-requires = ">=3.9"
 dependencies = [
     "dtyper",
     "gitpython",


### PR DESCRIPTION
The README specifies you need Python 3.9+ but you can install it on older versions (found this out the hard way) and it doesn't work.

This specifier will tell you at install time that your Python version is too old