### PR TITLE
render-engine init --skip-static still updates the static path

### DIFF
--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -184,6 +184,7 @@ def init(
                 site_description=site_description,
                 owner={"name": owner_name, "email": owner_email},
                 output_path=output_path,
+                skip_static=skip_static,
                 static_path=static_path,
                 collection_path=collection_path,
                 skip_collection=skip_collection,

--- a/src/render_engine/render_engine_templates/create_app_py.txt
+++ b/src/render_engine/render_engine_templates/create_app_py.txt
@@ -6,8 +6,9 @@ from render_engine import Site, Page, Collection
 
 app = Site()
 app.output_path = "{{output_path}}"
+{% if not skip_static %}
 app.static_paths.add("{{static_path}}")
-
+{% endif %}
 app.site_vars.update({
     {% if site_title %}
     SITE_TITLE:"{{site_title}}",

--- a/tests/tests_cli/conftest.py
+++ b/tests/tests_cli/conftest.py
@@ -43,3 +43,21 @@ def skip_collection_cli(tmp_path_factory):
         owner_email="hello@example.com",
         output_path=output_path,
     )
+
+
+@pytest.fixture(scope="session")
+def skip_static_cli(tmp_path_factory):
+    project_folder = tmp_path_factory.getbasetemp() / "test_skip_static_cli_app"
+    project_folder.mkdir()
+    output_path = tmp_path_factory.getbasetemp() / "default_skip_static_cli_output"
+
+    _cli.init(
+        skip_static=True,
+        project_folder=project_folder,
+        site_title="Test Site",
+        site_url="http://localhost:8000",
+        site_description="Test Site Description",
+        owner_name="Test Site Author",
+        owner_email="hello@example.com",
+        output_path=output_path,
+    )

--- a/tests/tests_cli/test_cli_builds_app.py
+++ b/tests/tests_cli/test_cli_builds_app.py
@@ -25,6 +25,15 @@ def test_cli_static_path(default_cli, tmp_path_factory):
     assert 'app.static_paths.add("static")' in temp_app.read_text()
 
 
+
+def test_cli_skips_static(skip_static_cli, tmp_path_factory):
+    """Asserts the static path is not in the app.py if the skip_static flag is set"""
+    temp_app = tmp_path_factory.getbasetemp() / "test_skip_static_cli_app" / "app.py"
+    assert 'app.static_paths.add("static")' not in temp_app.read_text()
+
+    assert 'static' not in list((tmp_path_factory.getbasetemp() / "test_skip_static_cli_app").iterdir())
+
+
 @pytest.mark.parametrize(
     "cli, exists",
     [


### PR DESCRIPTION
## Summary

<SUMMARY OF THE CHANGES BEING MADE>

## Type of Issue

- [X] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)

## Issues Referenced

Fixes #344

## Discussions Referenced

address <#DISCUSSION NUMBER>

## Next Steps

<ANY FURTHER STEPS TO BE TAKEN>
