### PR TITLE
render-engine serve build is now an Argument

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -50,15 +50,18 @@ The path to the folder that will contain your [`templates`](../templates). This 
 
 ::: src.render_engine.cli.cli.build
 
-`build` takes the `site_module` parameter in the format of `module:site`. `module` is the name of the python file that contains the `site` variable you've initialized. If the site `site` variable is in the `app.py` file, then the `site_module` parameter would be `app:site`.
+`build` requires a `module_site` parameter in the format of `module:site`. `module` is the name of the python file that contains the `site` variable you've initialized. If the site `site` variable is in the `app.py` file, then the `module_site` parameter would be `app:site`.
 
 ## Serving your site (locally) with `render-engine serve`
 
 The `serve` command creates a simple webserver that you can use to view your files. 
 
+`serve` requires a `module_site` argument in the format of `module:site`. `module` is the name of the python file that contains the `site` variable you've initialized. If the site `site` variable is in the `app.py` file, then the `module_site` parameter would be `app:site`.
+
+
 You can also use the `--reload` flag to have the site rebuild when changes are made.
 
 :::src.render_engine.cli.cli.serve
 
-> **NOTE**
-> `--reload` triggers a rebuild after re-importing the site object. Certain changes will not be picked up in the rebuild and reload.
+!!! Note
+    `--reload` triggers a rebuild after re-importing the site object. Certain changes will not be picked up in the rebuild and reload.

--- a/src/render_engine/cli/event.py
+++ b/src/render_engine/cli/event.py
@@ -1,5 +1,4 @@
 import importlib
-import sys
 import threading
 import time
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
@@ -32,14 +31,6 @@ def spawn_server(server_address: tuple[str, int], directory: str) -> ThreadingHT
         return ThreadingHTTPServer(server_address, _RequestHandler)
 
     return _httpd()
-
-
-def get_app(module_site: str) -> Site:
-    """Split the site module into a module and a class name"""
-    sys.path.insert(0, ".")
-    import_path, app_name = module_site.split(":", 1)
-    importlib.import_module(import_path)
-    return getattr(sys.modules[import_path], app_name)
 
 
 class RegExHandler(RegexMatchingEventHandler):
@@ -100,7 +91,7 @@ class RegExHandler(RegexMatchingEventHandler):
 
     def rebuild(self):
         console.print("[bold purple]Reloading and Rebuilding site...[/bold purple]")
-        import_path = self.module_site.split(":", 1)[0]
+        import_path = self.module_site[0]
         module = importlib.import_module(import_path)
         importlib.reload(module)
         self.app.render()

--- a/tests/tests_cli/test_cli_builds_app.py
+++ b/tests/tests_cli/test_cli_builds_app.py
@@ -1,5 +1,12 @@
 import pytest
+import typer
+from render_engine.cli.cli import split_module_site
 
+
+def test_module_site_raises_error_if_not():
+    """Asserts a typer BadParameter is raised if the module_site is not a module"""
+    with pytest.raises(typer.BadParameter):
+        split_module_site("Not Correct Format")
 
 def test_cli_author_owner(default_cli, tmp_path_factory):
     """Asserts there is a `OWNER` key"""


### PR DESCRIPTION
## Summary

- Makes serving the site trigger a build by default.
- Moves the module_site `split` to a callback that can raise an error if the 
- renames `site_module` to `module_site` with `cli.build`

## Type of Issue

- [ ] :bug: (bug)
- [X] :book: (Documentation)
- [X] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)

## Issues Referenced

resolves #328, #411
