### PR TITLE
Fix 'render_engine serve' AttributeError

### DIFF
--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -292,32 +292,29 @@ def serve(
     reload: Annotated[
         bool,
         typer.Option(
-            None,
             "--reload",
             "-r",
             help="Reload the server when files change",
         ),
-    ],
+    ] = None,
     directory: Annotated[
         str,
         typer.Option(
-            None,
             "--directory",
             "-d",
             help="Directory to serve",
             show_default=False,
         ),
-    ],
+    ] = None,
     port: Annotated[
         int,
         typer.Option(
-            8000,
             "--port",
             "-p",
             help="Port to serve on",
             show_default=False,
         ),
-    ],
+    ] = 8000,
 ):
     """
     Create an HTTP server to serve the site at `localhost`.


### PR DESCRIPTION
This pull request fixes the 'render_engine serve' command in the codebase that was causing an AttributeError. 

The issue was resolved by moving default values for the 'reload', 'directory', and 'port'  parameters in the 'serve' function to the correct position. This fix addresses #431.