### PR TITLE
Fix register theme and add test

### DIFF
--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -83,7 +83,7 @@ class Site:
         self.theme_manager.register_theme(theme)
 
         if theme.plugins:
-            self.plugin_manager._pm.register_plugins(*theme.plugins)
+            self.register_plugins(*theme.plugins)
 
     def register_themes(self, *themes: Theme):
         """

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -2,11 +2,13 @@ import pathlib
 
 import pluggy
 import pytest
-from jinja2 import FileSystemLoader
+from jinja2 import FileSystemLoader, DictLoader
 
 from render_engine.collection import Collection
 from render_engine.page import Page
 from render_engine.site import Site
+from render_engine.themes import Theme
+from render_engine.hookspecs import SiteSpecs
 
 pm = pluggy.PluginManager("fake_test")
 
@@ -295,3 +297,21 @@ def test_site_theme_update_settings():
     assert "test" not in site.site_vars
     site.update_theme_settings(test="test")
     assert site.site_vars["theme"]["test"] == "test"
+
+
+def test_plugin_in_theme_added_to_plugins():
+    """Tests that a plugin added to a theme is added to the site"""
+    class plugin(SiteSpecs):
+        pass
+    
+    class theme(Theme):
+        loader = DictLoader({"test.html": "test"})
+        plugins = [plugin]
+        filters = []
+
+
+    site = Site()
+    site.register_theme(
+        theme,
+    )
+    assert plugin in site.plugin_manager.plugins


### PR DESCRIPTION
This pull request fixes the register_theme function by updating the code to correctly register plugins from a theme. 

It also adds a test to ensure that a plugin added to a theme is properly added to the site.