### PR TITLE
fixes 🐛  - Archive isn't getting class page name #442

### DIFF
--- a/src/render_engine/archive.py
+++ b/src/render_engine/archive.py
@@ -38,6 +38,8 @@ class Archive(BasePage):
         plugin_manager: PluginManager | None = None,
     ) -> None:
         super().__init__()
+        self.slug = title
+        self.title = title
         self.archive_index = archive_index
 
         if archive_index:
@@ -46,5 +48,4 @@ class Archive(BasePage):
         self.plugin_manager = plugin_manager
         self.routes = routes
         self.template = template
-        self.title = title
         self.template_vars = template_vars

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,18 +1,26 @@
+import pytest
+
 from render_engine.archive import Archive
 from render_engine.page import Page
 
 
-def test_archive_slug_name_with_pages():
+def test_archive_slug_named_after_title():
+    """Archives usually get their name from their collection. This tests that the slug is named after the title"""
+
+    archive = Archive(title="test archive", pages=[Page()], template="", routes=["./"], template_vars={})
+
+    assert archive._slug == "test-archive"
+
+
+@pytest.mark.parametrize(
+    "title, expected_slug",
+    [("archive", "archive1"), ("collection", "collection1"), ("Test Collection", "test-collection1")],
+)
+def test_archive_slug_name_with_pages(title, expected_slug):
     """tests that if num_archive_pages is greater than 1, the slug is appended with the archive_index"""
 
     archive = Archive(
-        title="archive",
-        pages=[Page()],
-        template="",
-        routes=["./"],
-        archive_index=1,
-        num_archive_pages=2,
-        template_vars={}
+        title=title, pages=[Page()], template="", routes=["./"], archive_index=1, num_archive_pages=2, template_vars={}
     )
 
-    assert archive.slug == "archive1"
+    assert archive._slug == expected_slug


### PR DESCRIPTION
ensures that the Archive class sets its slug to the title

## Type of Issue

- [X] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)

## Issues/Discussions Referenced

resolves #442

