### PR TITLE
Move plugins into plugins.py

### DIFF
--- a/docs/docs/hookspecs.md
+++ b/docs/docs/hookspecs.md
@@ -1,1 +1,1 @@
-:::src.render_engine.hookspecs
+:::src.render_engine.plugins

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -26,7 +26,7 @@ nav:
       - Site: site.md
   - Extending Render Engine:
     - Plugins: plugins.md
-    - Plugins Entrypoints: hookspecs.md
+    - Plugins Entrypoints: plugins.md
     - Built-in Plugins: plugins.md
   - Parsers: parsers.md
   - CLI: cli.md

--- a/src/render_engine/extras/clean_output.py
+++ b/src/render_engine/extras/clean_output.py
@@ -2,7 +2,7 @@ import logging
 import shutil
 import typing
 
-from render_engine.hookspecs import hook_impl
+from render_engine.plugins import hook_impl
 from render_engine.site import Site
 
 

--- a/src/render_engine/extras/site_map.py
+++ b/src/render_engine/extras/site_map.py
@@ -2,7 +2,7 @@ import logging
 import pathlib
 
 from render_engine.engine import engine
-from render_engine.hookspecs import hook_impl
+from render_engine.plugins import hook_impl
 from render_engine.site import Site
 
 

--- a/src/render_engine/plugins.py
+++ b/src/render_engine/plugins.py
@@ -16,14 +16,14 @@ class SiteSpecs:
     @hook_spec
     def add_default_settings(
         self,
-        site: "Site",
+        site,
     ) -> None:
         """Add default settings to the site"""
 
     @hook_spec
     def pre_build_site(
         self,
-        site: "Site",
+        site,
         settings: dict[str, typing.Any],
     ) -> None:
         """Steps Prior to Building the site"""
@@ -31,14 +31,14 @@ class SiteSpecs:
     @hook_spec
     def post_build_site(
         self,
-        site: "Site",
+        site,
     ) -> None:
         """Build After Building the site"""
 
     @hook_spec
     def render_content(
         self,
-        page: "page",
+        page,
         settings: dict[str, typing.Any],
     ) -> None:
         """
@@ -48,9 +48,9 @@ class SiteSpecs:
     @hook_spec
     def post_render_content(
         self,
-        page: "page",
+        page,
         settings: dict[str : typing.Any],
-        site: "Site",
+        site,
     ) -> None:
         """
         Augments the content of the page before it is rendered as output.
@@ -59,7 +59,7 @@ class SiteSpecs:
     @hook_spec
     def pre_build_collection(
         self,
-        collection: "Collection",
+        collection,
         settings: dict[str, typing.Any],
     ) -> None:
         """Steps Prior to Building the collection"""
@@ -67,7 +67,7 @@ class SiteSpecs:
     @hook_spec
     def post_build_collection(
         self,
-        site: "Site",
+        site,
         settings: dict[str, typing.Any],
     ) -> None:
         """Build After Building the collection"""

--- a/src/render_engine/plugins.py
+++ b/src/render_engine/plugins.py
@@ -1,8 +1,76 @@
+import typing
 from collections import defaultdict
 
 import pluggy
 
-from .hookspecs import _PROJECT_NAME, SiteSpecs
+_PROJECT_NAME = "render_engine"
+hook_impl = pluggy.HookimplMarker(project_name=_PROJECT_NAME)
+hook_spec = pluggy.HookspecMarker(project_name=_PROJECT_NAME)
+
+
+class SiteSpecs:
+    """Plugin hook specifications for the Site class"""
+
+    default_settings: dict[str, typing.Any]
+
+    @hook_spec
+    def add_default_settings(
+        self,
+        site: "Site",
+    ) -> None:
+        """Add default settings to the site"""
+
+    @hook_spec
+    def pre_build_site(
+        self,
+        site: "Site",
+        settings: dict[str, typing.Any],
+    ) -> None:
+        """Steps Prior to Building the site"""
+
+    @hook_spec
+    def post_build_site(
+        self,
+        site: "Site",
+    ) -> None:
+        """Build After Building the site"""
+
+    @hook_spec
+    def render_content(
+        self,
+        page: "page",
+        settings: dict[str, typing.Any],
+    ) -> None:
+        """
+        Augments the content of the page before it is rendered as output.
+        """
+
+    @hook_spec
+    def post_render_content(
+        self,
+        page: "page",
+        settings: dict[str : typing.Any],
+        site: "Site",
+    ) -> None:
+        """
+        Augments the content of the page before it is rendered as output.
+        """
+
+    @hook_spec
+    def pre_build_collection(
+        self,
+        collection: "Collection",
+        settings: dict[str, typing.Any],
+    ) -> None:
+        """Steps Prior to Building the collection"""
+
+    @hook_spec
+    def post_build_collection(
+        self,
+        site: "Site",
+        settings: dict[str, typing.Any],
+    ) -> None:
+        """Build After Building the collection"""
 
 
 class PluginManager:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,12 +1,10 @@
-import logging
-import pathlib
 import typing
 
 import pytest
 
 from render_engine.collection import Collection
-from render_engine.hookspecs import hook_impl
 from render_engine.page import Page
+from render_engine.plugins import hook_impl
 from render_engine.site import Site
 
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -2,13 +2,13 @@ import pathlib
 
 import pluggy
 import pytest
-from jinja2 import FileSystemLoader, DictLoader
+from jinja2 import DictLoader, FileSystemLoader
 
 from render_engine.collection import Collection
 from render_engine.page import Page
+from render_engine.plugins import SiteSpecs
 from render_engine.site import Site
 from render_engine.themes import Theme
-from render_engine.hookspecs import SiteSpecs
 
 pm = pluggy.PluginManager("fake_test")
 
@@ -44,7 +44,7 @@ def test_site_site_vars_orrider_defaults_via_class():
     assert site.site_vars["SITE_URL"] == "https://my-site.com"
 
 
-def test_site_page_in_route_list(tmp_path):
+def test_site_page_in_route_list(tmp_path: pathlib.Path):
     tmp_dir = tmp_path / "content"
     tmp_dir.mkdir()
     file = tmp_dir / "test.md"
@@ -100,7 +100,7 @@ def test_site_page_with_multiple_routes_has_one_entry_in_routes_list():
     assert len(site.route_list) == 1
 
 
-def test_url_for_Page_in_site(tmp_path):
+def test_url_for_Page_in_site(tmp_path: pathlib.Path):
     """Tests that url_for a page is added to a template"""
     test_template = pathlib.Path(tmp_path / "template.html")
     test_template.write_text("The URL is '{{ 'custompage'|url_for }}'")
@@ -118,7 +118,7 @@ def test_url_for_Page_in_site(tmp_path):
     assert custom_page.read_text() == "The URL is '/custompage.html'"
 
 
-def test_collection_archive_in_route_list(tmp_path):
+def test_collection_archive_in_route_list(tmp_path: pathlib.Path):
     """Given a collection with an archive, the archive should be in the route list and accessible with url_for"""
     test_collection_archive_template = pathlib.Path(tmp_path / "archive_template.html")
     test_collection_archive_template.write_text("This is the collection archive")
@@ -150,7 +150,7 @@ def test_collection_archive_in_route_list(tmp_path):
 
 
 @pytest.fixture(scope="module")
-def site(tmp_path_factory):
+def site(tmp_path_factory: pytest.TempPathFactory):
 
     collection_archive_path = tmp_path_factory.getbasetemp() / "collection_archive_items"
     collection_archive_output_path = collection_archive_path / "output" 
@@ -179,7 +179,7 @@ def site(tmp_path_factory):
     return site
 
 
-def test_collection_archives_generates_by_items_per_page(site):
+def test_collection_archives_generates_by_items_per_page(site: Site):
     """
     Archive pages should be created using the items_per_page value
     
@@ -193,14 +193,14 @@ def test_collection_archives_generates_by_items_per_page(site):
     assert len(list(site.route_list["custompagescollection"].archives)) == 3
 
 
-def test_collection_archive_pages_in_route_list(site):
+def test_collection_archive_pages_in_route_list(site: Site):
     """Given a collection with an archive, the archive should be in the route list and accessible with url_for"""
 
     for page in site.route_list['custompagescollection'].archives:
         assert pathlib.Path(site.output_path / page.path_name).exists()
 
 
-def test_url_for_Collection_in_site(tmp_path):
+def test_url_for_Collection_in_site(tmp_path: pathlib.Path):
     """
     Tests that url_for a page in a collection is added to a template
     """
@@ -225,7 +225,7 @@ def test_url_for_Collection_in_site(tmp_path):
     assert custom_page.read_text() == "The URL is '/customcollectionpage.html'"
 
 
-def test_site_output_path(tmp_path):
+def test_site_output_path(tmp_path: pathlib.Path):
     """Tests site outputs to output_path"""
 
     output_tmp_dir = tmp_path / "output"
@@ -245,7 +245,7 @@ def test_site_output_path(tmp_path):
     assert (output_tmp_dir / "custompage.html").exists()
 
 
-def test_site_static_renders_in_static_output_path(site):
+def test_site_static_renders_in_static_output_path(site: Site):
     """
     Tests that a static file is rendered in the static output path.
     """
@@ -254,7 +254,7 @@ def test_site_static_renders_in_static_output_path(site):
     assert (site.output_path / "static" / "test.txt").exists()
 
 
-def tests_site_nested_static_paths(tmp_path, site):
+def tests_site_nested_static_paths(tmp_path: pathlib.Path, site: Site):
     """given a static path with nested directories, the output should be the same"""
     static_tmp_dir = tmp_path / "static"
     output_tmp_dir = tmp_path / "output"
@@ -271,7 +271,7 @@ def tests_site_nested_static_paths(tmp_path, site):
     assert (output_tmp_dir / "static" / "nested" / "test.txt").exists()
 
 
-def tests_site_multiple_static_paths(tmp_path, site):
+def tests_site_multiple_static_paths(tmp_path: pathlib.Path, site: Site):
     """given a static path with nested directories, the output should be the same"""
     static_tmp_dir = tmp_path / "static"
     output_tmp_dir = tmp_path / "output"


### PR DESCRIPTION
This pull request moves the plugins from the `hookspecs.py` file to the `plugins.py` file for better organization.