### PR TITLE
Can't overwrite plugins_settings when registering values since `update` is called.

### DIFF
--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -77,11 +77,11 @@ class Site:
             logging.debug("Registering Plugin: %s", plugin.__name__)
             self.plugin_manager.register_plugin(plugin)
             logging.debug("Loading default settings: %s", getattr(plugin, "default_settings", {}))
-            self.plugin_manager.plugin_settings[plugin.__name__].update(
+            self.plugin_manager.plugin_settings[plugin.__name__] = {
                 **getattr(plugin, "default_settings", {}),
                 **getattr(self.plugin_settings, plugin.__name__, {}),
                 **plugin_settings.get(plugin.__name__, {}),
-            )
+            }
 
     def register_theme(self, theme: Theme):
         """Overrides the ThemeManager register_theme method to add plugins to the site"""

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -5,9 +5,8 @@ import pytest
 
 from render_engine.collection import Collection
 from render_engine.page import Page
-from render_engine.plugins import hook_impl
+from render_engine.plugins import PluginManager, hook_impl
 from render_engine.site import Site
-from render_engine.plugins import PluginManager
 
 
 class FakePlugin:
@@ -129,3 +128,10 @@ def test_plugin_multiple_plugins():
     plugin_mgr.register_plugin(FakePlugin)
     plugin_mgr.register_plugin(FakePlugin)
     
+
+def test_plugin_override_settings_from_site_register_plugins():
+    """Asserts that the settings passed into `register_plugins` override the default settings"""
+
+    site = Site()
+    site.register_plugins(FakePlugin, FakePlugin={"test": "override"})
+    assert site.plugin_manager.plugin_settings.get("FakePlugin")["test"] == "override"


### PR DESCRIPTION
Fixes #499

<!-- 
SUMMARY OF THE CHANGES BEING MADE 
Be sure to include any referenced issues and discussions.
-->

## Type of Issue

- [X] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)
  
## Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

## Changes have been Tested

- [x] YES - Changes have been tested

## Next Steps

<!--ANY FURTHER STEPS TO BE TAKEN-->
