### PR TITLE
Fix url_for() in template calls

### DIFF
--- a/src/render_engine/render_engine_templates/archive.html
+++ b/src/render_engine/render_engine_templates/archive.html
@@ -2,6 +2,6 @@
 {% block content %}
   <h1>{{collection_title}}</h1>
   {% for page in pages %}
-  <div><a href="{{page.url_for}}">{{page}}</a></div>
+  <div><a href="{{page.url_for()}}">{{page}}</a></div>
   {% endfor %}
 {% endblock %}


### PR DESCRIPTION
Fixes #520

Fixes the `archive.html` call for `url_for`.
# Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)
  
## Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

## Changes have been Tested

- [ ] YES - Changes have been tested

## Next Steps

<!--ANY FURTHER STEPS TO BE TAKEN-->
