### PR TITLE
Fix clean folder function

### DIFF
--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -184,7 +184,7 @@ def build(
     module, site = module_site
     app = get_app(module, site)
     if clean:
-        remove_output_folder(app.output_path)
+        remove_output_folder(pathlib.Path(app.output_path))
     app.render()
 
 
@@ -250,7 +250,7 @@ def serve(
     app = get_app(module, site)
 
     if clean:
-        remove_output_folder(app.output_path)
+        remove_output_folder(pathlib.Path(app.output_path))
     app.render()
 
     if not directory:

--- a/tests/tests_cli/test_render_engine_tools.py
+++ b/tests/tests_cli/test_render_engine_tools.py
@@ -1,0 +1,17 @@
+import pathlib
+import pytest
+from render_engine.cli.cli import remove_output_folder
+
+from render_engine.site import Site
+
+def test_clean_folder(tmp_path):
+    site = Site()
+    site.output_path = tmp_path
+    dirty_output_path = tmp_path / "test" # Tests that nested folders are also removed
+    dirty_output_path.mkdir()
+    dirty_output_path.joinpath("test.txt").touch()
+    assert dirty_output_path.exists()
+
+    remove_output_folder(pathlib.Path(dirty_output_path))
+    assert not dirty_output_path.exists()
+    assert not list(tmp_path.iterdir())


### PR DESCRIPTION
This pull request fixes the clean_folder function in the CLI module. Previously, the function was passed in string. 

This PR also adds a test case to ensure that files and folders are properly removed when using the clean_folder function.