### PR TITLE
remove pinning from test and pytest-lazy-fixture

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,4 +1,2 @@
 python -m pip install --user --upgrade pip
-python -m pip install --user pip-tools
-python -m piptools compile --upgrade --extra=dev -o requirements.txt pyproject.toml
-python -m pip install --user -r requirements.txt
+python -m pip install .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dev = [
     "cookiecutter",
     "pytest",
     "pytest-mock",
-    "pytest-lazy-fixtures",
     "mkdocs",
     "mkdocs-material",
     "mkdocstrings[python]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,9 @@ extras = [
 ]
 dev = [
     "cookiecutter",
-    "pytest<8",
+    "pytest",
     "pytest-mock",
-    "pytest-lazy-fixture",
+    "pytest-lazy-fixtures",
     "mkdocs",
     "mkdocs-material",
     "mkdocstrings[python]",


### PR DESCRIPTION
Fixes #556

In a recent refactor of tests we actually removed the need for pytest-lazy-fixture and could remove the dependency completely

# Type of Issue

- [X] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)
  
## Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

## Changes have been Tested

- [X] YES - Changes have been tested