### PR TITLE
fix #606 serve regex

### DIFF
--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -267,7 +267,7 @@ def serve(
         app=app,
         module_site=module_site,
         patterns=None,
-        ignore_patterns=[r".*output\\*.+$", r"\.\\\..+$", r".*__.*+$"],
+        ignore_patterns=[r".*output\\*.+$", r"\.\\\..+$", r".*__.*$"],
     )
 
     console = Console()


### PR DESCRIPTION
<!-- 
SUMMARY OF THE CHANGES BEING MADE 
Be sure to include any referenced issues and discussions.
-->

# Type of Issue

- [X] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)
  
## Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

## Changes have been Tested

- [X] YES - Changes have been tested

## Next Steps

The pattern r".__.+$" is not valid because it contains .+ which is an invalid sequence in regex.

In regex, means "zero or more of the preceding element" and + means "one or more of the preceding element". So .+ is an invalid combination because it's unclear whether it should match zero or more or one or more of the preceding element.

If you want to match any string that contains two underscores, you can use the following pattern:

r".__.*$"
