### PR TITLE
532 title from content path

### DIFF
--- a/src/render_engine/_base_object.py
+++ b/src/render_engine/_base_object.py
@@ -1,5 +1,6 @@
 """Shared Properties and methods across render_engine objects."""
 
+import logging
 from slugify import slugify
 
 
@@ -22,7 +23,15 @@ class BaseObject:
         The title of the Page
         If no title is provided, use the class name.
         """
-        return getattr(self, "title", self.__class__.__name__)
+        if title := getattr(self, "title", None):
+            return title
+        else:
+            logging.warning(
+                f'No title provided for {self.__class__.__name__}. \
+                Using "{self.__class__.__name__}" as title. \
+                This can cause files to be overwritten'
+            )
+            return self.__class__.__name__
 
     @property
     def _slug(self) -> str:

--- a/src/render_engine/_base_object.py
+++ b/src/render_engine/_base_object.py
@@ -1,6 +1,7 @@
 """Shared Properties and methods across render_engine objects."""
 
 import logging
+
 from slugify import slugify
 
 

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -43,7 +43,9 @@ def test_page_from_template(tmp_path: pathlib.Path):
         title = "Test Page"
         template = "test.html"
 
-    environment = jinja2.Environment(loader=jinja2.DictLoader({"test.html": "{{ title }}"}))
+    environment = jinja2.Environment(
+        loader=jinja2.DictLoader({"test.html": "{{ title }}"})
+    )
 
     page = CustomPage()
     assert page._render_content(engine=environment) == "Test Page"
@@ -69,4 +71,14 @@ def test_rendered_page_from_template_has_attributes():
     class CustomPage(Page):
         template = environment.get_template("test.html")
 
-    assert CustomPage()._render_from_template(template=CustomPage.template) == "CustomPage-custompage-/custompage.html"
+    assert (
+        CustomPage()._render_from_template(template=CustomPage.template)
+        == "CustomPage-custompage-/custompage.html"
+    )
+
+
+def test_page_with_no_title_raises_warning(caplog):
+    """Tests that a page with no title raises a warning"""
+    with caplog.at_level("WARNING"):
+        page = Page()
+        page._title


### PR DESCRIPTION
Raises a `Warning` when you don't provide a title.

This is to encourage setting a title and preventing files from being overwritten.

# Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [x] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)
  
## Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

## Changes have been Tested

- [x] YES - Changes have been tested

## Next Steps

It may make sense to provide more context in other objects. For example if you have multiple objects being made in a collection. You wouldn't be able to know which of the items were being generated. This is why #532 suggests checking for content_path

<!--ANY FURTHER STEPS TO BE TAKEN-->
