### PR TITLE
refactor-cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,9 @@ version_toml = "pyproject.toml:project.version"
 branch = "main"
 
 [tool.ruff]
-lint.select = ["E", "F", "I", "UP"]
+line-length = 120
+indent-width = 4
 target-version = "py312"
-lint.pycodestyle.max-line-length = 120
-src = ["src"]
-lint.ignore-init-module-imports = true
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]

--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -20,9 +20,7 @@ app = typer.Typer()
 def get_site_content_paths(site: Site) -> list[Path | None]:
     """Get the content paths from the route_list in the Site"""
 
-    base_paths = map(
-        lambda x: getattr(x, "content_path", None), site.route_list.values()
-    )
+    base_paths = map(lambda x: getattr(x, "content_path", None), site.route_list.values())
     return list(filter(lambda x: x is not None, base_paths))
 
 
@@ -59,9 +57,7 @@ def get_available_themes(console: Console, site: Site, theme_name: str) -> list[
         return []
 
 
-def display_filtered_templates(
-    title: str, templates_list: list[str], filter_value: str
-) -> None:
+def display_filtered_templates(title: str, templates_list: list[str], filter_value: str) -> None:
     """Display filtered templates based on a given filter value."""
     table = Table(title=title)
     table.add_column("[bold blue]Templates[bold blue]")
@@ -74,12 +70,8 @@ def display_filtered_templates(
 @app.command()
 def templates(
     module_site: Annotated[tuple[str, str], typer.Argument(callback=split_module_site)],
-    theme_name: Annotated[
-        str, typer.Option("--theme-name", help="Theme to search templates in")
-    ] = "",
-    filter_value: Annotated[
-        str, typer.Option("--filter-value", help="Filter templates based on names")
-    ] = "",
+    theme_name: Annotated[str, typer.Option("--theme-name", help="Theme to search templates in")] = "",
+    filter_value: Annotated[str, typer.Option("--filter-value", help="Filter templates based on names")] = "",
 ):
     """
     CLI for listing available theme templates.
@@ -102,9 +94,7 @@ def templates(
                 filter_value,
             )
     else:
-        console.print(
-            "[red]No theme name specified. Listing all installed themes and their templates[red]"
-        )
+        console.print("[red]No theme name specified. Listing all installed themes and their templates[red]")
         for theme_prefix, theme_loader in site.theme_manager.prefix.items():
             templates_list = theme_loader.list_templates()
             display_filtered_templates(
@@ -131,9 +121,7 @@ def init(
         ]
         | None
     ) = None,
-    no_input: Annotated[
-        bool, typer.Option("--no-input", help="Do not prompt for parameters")
-    ] = False,
+    no_input: Annotated[bool, typer.Option("--no-input", help="Do not prompt for parameters")] = False,
     output_dir: Annotated[
         Path,
         typer.Option(
@@ -143,9 +131,7 @@ def init(
             exists=True,
         ),
     ] = Path("./"),
-    cookiecutter_args: Annotated[
-        Path, typer.Option(callback=lambda x: json.loads(x))
-    ] = {},
+    cookiecutter_args: Annotated[Path, typer.Option(callback=lambda x: json.loads(x))] = {},
 ) -> None:
     """
     Create a new site configuration. You can provide extra_context to the cookiecutter template.

--- a/src/render_engine/cli/event.py
+++ b/src/render_engine/cli/event.py
@@ -11,9 +11,7 @@ from render_engine import Site
 console = Console()
 
 
-def spawn_server(
-    server_address: tuple[str, int], directory: str
-) -> ThreadingHTTPServer:
+def spawn_server(server_address: tuple[str, int], directory: str) -> ThreadingHTTPServer:
     """
         Create and return an instance of ThreadingHTTPServer that serves files
     from the specified directory.

--- a/src/render_engine/cli/event.py
+++ b/src/render_engine/cli/event.py
@@ -3,9 +3,8 @@ import threading
 import time
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 
+import watchfiles
 from rich.console import Console
-from watchdog.events import FileSystemEvent, RegexMatchingEventHandler
-from watchdog.observers import Observer
 
 from render_engine import Site
 
@@ -20,9 +19,8 @@ def spawn_server(
     from the specified directory.
 
     Params:
-            server_address: A tuple of a string and integer representing the server address (host, port).
-            directory: A string representing the directory from which the server should serve files.
-
+        server_address: A tuple of a string and integer representing the server address (host, port).
+        directory: A string representing the directory from which the server should serve files.
     """
 
     class _RequestHandler(SimpleHTTPRequestHandler):
@@ -35,22 +33,22 @@ def spawn_server(
     return _httpd()
 
 
-class RegExHandler(RegexMatchingEventHandler):
+class ServerEventHandler:
     """
-    Initializes a handler that looks for file changes in a directory (`dir_to_watch`), as
+    Initializes a handler that looks for file changes in a directory (`dirs_to_watch`), as
     well as creates a server to serve files in a given directory (`dir_to_serve`). The
     class contains helper methods to manage server events in a thread.
 
     Meanwhile, the `watch` method uses an instance of this handler class to monitor for file
-    changes. The files to be monitored are all files/directories within the `dir_to_watch`,
+    changes. The files to be monitored are all files/directories within the `dirs_to_watch`,
     which defaults to the project root directory. The `patterns` and `ignore_patterns` are used
     to filter the files to be monitored using regular expressions.
 
     Params:
         server_address: A tuple of the form (host, port)
         dir_to_serve: The directory to serve
-        app: A Site instance
-        dir_to_watch: The directory to watch
+        site: A Site instance
+        dirs_to_watch: The directories to watch
         patterns: A list of regular expressions to filter files
         ignore_patterns: A list of regular expressions to ignore
     """
@@ -59,54 +57,61 @@ class RegExHandler(RegexMatchingEventHandler):
         self,
         server_address: tuple[str, int],
         dir_to_serve: str,
-        app: Site,
-        module_site: tuple[str, str],
-        dir_to_watch: str = ".",
+        import_path: str,
+        site: Site,
+        dirs_to_watch: str | None = None,
         patterns: list[str] | None = None,
         ignore_patterns: list[str] | None = None,
         *args,
         **kwargs,
     ) -> None:
         self.p = None
-        self._server = spawn_server
         self.server_address = server_address
-        self.dir_to_serve = (dir_to_serve,)
-        self.app = app
-        self.module_site = module_site
-        self.dir_to_watch = dir_to_watch
+        self.import_path = import_path
+        self.dir_to_serve = dir_to_serve
+        self.site = site
+        self.dirs_to_watch = dirs_to_watch
         self.patterns = patterns
         self.ignore_patterns = ignore_patterns
-        super().__init__(*args, **kwargs)
 
     def start_server(self) -> None:
-        console.print(
-            f"[bold green]Spawning server on http://{self.server_address[0]}:{self.server_address[1]}[/bold green]"
-        )
-        self._server = spawn_server(self.server_address, self.dir_to_serve[0])
-        self._thread = threading.Thread(target=self._server.serve_forever)
+        if not getattr(self, "server", False):
+            console.print(
+                f"[bold green]Spawning server on http://{self.server_address[0]}:{self.server_address[1]}[/bold green]"
+            )
+            self.server = spawn_server(self.server_address, self.dir_to_serve)
+        self._thread = threading.Thread(target=self.server.serve_forever)
         self._thread.start()
 
     def stop_server(self) -> None:
         console.print("[bold red]Stopping server[/bold red]")
-        self._server.shutdown()
+        self.server.shutdown()
         self._thread.join()
 
     def rebuild(self) -> None:
         console.print("[bold purple]Reloading and Rebuilding site...[/bold purple]")
-        import_path = self.module_site[0]
-        module = importlib.import_module(import_path)
+        module = importlib.import_module(self.import_path)
         importlib.reload(module)
-        self.app.render()
+        self.site.render()
 
-    def on_any_event(self, event: FileSystemEvent) -> None:
-        if event.is_directory:
-            return None
-        self.rebuild()
+    def stop_watcher(self) -> bool:
+        """
+        logic to stop the watcher.
+
+        By default this code looks for the KeyboardInterrupt
+        """
+
+        # return if keyboard interrupt is raised
+        try:
+            time.sleep(1)
+            return False
+        except KeyboardInterrupt:
+            return True
 
     def watch(self) -> None:
         """
         This function `watch` starts the server on the output path (`dir_to_serve`)
-        and monitors the specified directory (`dir_to_watch`) for changes.
+        and monitors the specified directories in (`dirs_to_watch`) for changes.
 
         After it starts the server, it "waits" and monitors the directory for
         changes. If a change is detected, the `on_any_event` method is called,
@@ -116,19 +121,24 @@ class RegExHandler(RegexMatchingEventHandler):
         If a KeyboardInterrupt is raised, it stops the observer and server.
         """
 
-        console.print(f"[yellow]Serving {self.app.output_path}[/yellow]")
+        console.print(f"[yellow]Serving {self.site.output_path}[/yellow]")
+        while not self.stop_watcher():
+            if self.dirs_to_watch:
+                for _ in watchfiles.watch(*self.dirs_to_watch):
+                    self.rebuild()
 
-        observer = Observer()
-        observer.schedule(self, self.dir_to_watch, recursive=True)
-        self.start_server()
-        observer.start()
-
+    def __enter__(self):
+        """Starting Context manager for the class"""
         try:
-            while True:
-                time.sleep(1)
-        except KeyboardInterrupt:
-            console.print("watcher terminated by keystroke")
-            observer.stop()
-            self.stop_server()
-        observer.join()
+            self._thread.server_close()
+        except AttributeError:
+            pass
+        self.start_server()
+        self.watch()
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        """Stopping Context manager for the class"""
+
+        self.stop_server()
         console.print("[bold red]FIN![/bold red]")
+        return None

--- a/src/render_engine/collection.py
+++ b/src/render_engine/collection.py
@@ -102,9 +102,7 @@ class Collection(BaseObject):
 
     def iter_content_path(self):
         """Iterate through in the collection's content path."""
-        return flatten(
-            [Path(self.content_path).glob(suffix) for suffix in self.include_suffixes]
-        )
+        return flatten([Path(self.content_path).glob(suffix) for suffix in self.include_suffixes])
 
     def _generate_content_from_modified_pages(
         self,

--- a/src/render_engine/engine.py
+++ b/src/render_engine/engine.py
@@ -46,9 +46,7 @@ engine.filters["to_pub_date"] = to_pub_date
 
 
 @pass_environment
-def format_datetime(
-    env: Environment, value: datetime, datetime_format: str | None = None
-) -> str:
+def format_datetime(env: Environment, value: datetime, datetime_format: str | None = None) -> str:
     """Parse information from the given class object."""
     if datetime_format:
         format = datetime_format

--- a/src/render_engine/page.py
+++ b/src/render_engine/page.py
@@ -94,8 +94,7 @@ class BasePage(BaseObject):
 
         except AttributeError:
             raise AttributeError(
-                f"{self} does not have a content attribute. "
-                "You must either provide a template or content."
+                f"{self} does not have a content attribute. " "You must either provide a template or content."
             )
 
     def __str__(self):
@@ -190,6 +189,4 @@ class Page(BasePage):
         Returns:
             Any: The parsed content of the page.
         """
-        return self.Parser.parse(
-            self.content, extras=getattr(self, "parser_extras", {})
-        )
+        return self.Parser.parse(self.content, extras=getattr(self, "parser_extras", {}))

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -67,9 +67,7 @@ class Site:
         self.subcollections: dict[str, list] = {"pages": []}
         self.theme_manager.engine.globals.update(self.site_vars)
         if self.theme_manager.engine.loader is not None:
-            self.theme_manager.engine.loader.loaders.insert(
-                0, FileSystemLoader(self._template_path)
-            )
+            self.theme_manager.engine.loader.loaders.insert(0, FileSystemLoader(self._template_path))
 
     @property
     def output_path(self) -> Path | str:
@@ -95,9 +93,7 @@ class Site:
         for plugin in plugins:
             logging.debug("Registering Plugin: %s", plugin.__name__)
             self.plugin_manager.register_plugin(plugin)
-            logging.debug(
-                "Loading default settings: %s", getattr(plugin, "default_settings", {})
-            )
+            logging.debug("Loading default settings: %s", getattr(plugin, "default_settings", {}))
             self.plugin_manager.plugin_settings[plugin.__name__] = {
                 **getattr(plugin, "default_settings", {}),
                 **getattr(self.plugin_settings, plugin.__name__, {}),
@@ -211,16 +207,12 @@ class Site:
         settings = {**self.site_settings.get("plugins", {}), **{"route": route}}
 
         if hasattr(page, "plugin_manager") and page.plugin_manager is not None:
-            page.plugin_manager._pm.hook.render_content(
-                page=page, settings=settings, site=self
-            )
+            page.plugin_manager._pm.hook.render_content(page=page, settings=settings, site=self)
         page.rendered_content = page._render_content(engine=self.theme_manager.engine)
         # pass the route to the plugin settings
 
         if hasattr(page, "plugin_manager") and page.plugin_manager is not None:
-            page.plugin_manager._pm.hook.post_render_content(
-                page=page.__class__, settings=settings, site=self
-            )
+            page.plugin_manager._pm.hook.post_render_content(page=page.__class__, settings=settings, site=self)
 
         return path.write_text(page.rendered_content)
 
@@ -277,9 +269,7 @@ class Site:
                 self.theme_manager.engine.loader.loaders.insert(-1, theme_loader)
         # load themes in the PrefixLoader
         if self.theme_manager.engine.loader is not None:
-            self.theme_manager.engine.loader.loaders.insert(
-                -1, PrefixLoader(self.theme_manager.prefix)
-            )
+            self.theme_manager.engine.loader.loaders.insert(-1, PrefixLoader(self.theme_manager.prefix))
 
     @property
     def template_path(self) -> str:
@@ -290,9 +280,7 @@ class Site:
     @template_path.setter
     def template_path(self, template_path: str) -> None:
         if self.theme_manager.engine.loader is not None:
-            self.theme_manager.engine.loader.loaders.insert(
-                0, FileSystemLoader(template_path)
-            )
+            self.theme_manager.engine.loader.loaders.insert(0, FileSystemLoader(template_path))
 
     def render(self) -> None:
         """
@@ -310,16 +298,12 @@ class Site:
 
         with Progress() as progress:
             pre_build_task = progress.add_task("Loading Pre-Build Plugins", total=1)
-            self.plugin_manager._pm.hook.pre_build_site(
-                site=self, settings=self.site_settings.get("plugins", {})
-            )  # type: ignore
+            self.plugin_manager._pm.hook.pre_build_site(site=self, settings=self.site_settings.get("plugins", {}))  # type: ignore
 
             self.load_themes()
             self.theme_manager.engine.globals.update(self.site_vars)
             # Parse Route List
-            task_add_route = progress.add_task(
-                "[blue]Adding Routes", total=len(self.route_list)
-            )
+            task_add_route = progress.add_task("[blue]Adding Routes", total=len(self.route_list))
 
             self.theme_manager._render_static()
 
@@ -327,9 +311,7 @@ class Site:
             self.theme_manager.engine.globals["routes"] = self.route_list
 
             for slug, entry in self.route_list.items():
-                progress.update(
-                    task_add_route, description=f"[blue]Adding[gold]Route: [blue]{slug}"
-                )
+                progress.update(task_add_route, description=f"[blue]Adding[gold]Route: [blue]{slug}")
                 if isinstance(entry, Page):
                     for route in entry.routes:
                         progress.update(

--- a/src/render_engine/themes.py
+++ b/src/render_engine/themes.py
@@ -75,9 +75,7 @@ class ThemeManager:
     output_path: Path | str
     prefix: dict[str, BaseLoader] = dataclasses.field(default_factory=dict)
     static_paths: set = dataclasses.field(default_factory=set)
-    template_globals: dict[str, set] = dataclasses.field(
-        default_factory=default_template_globals
-    )
+    template_globals: dict[str, set] = dataclasses.field(default_factory=default_template_globals)
 
     def register_theme(self, theme: Theme):
         """
@@ -96,9 +94,7 @@ class ThemeManager:
 
         if theme.template_globals:
             for key, value in theme.template_globals.items():
-                if isinstance(value, set) and isinstance(
-                    self.engine.globals.get(key), set
-                ):
+                if isinstance(value, set) and isinstance(self.engine.globals.get(key), set):
                     self.engine.globals.setdefault(key, set()).update(value)
                 if isinstance(self.engine.globals.get(key), set):
                     self.engine.globals[key].add(value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 from jinja2 import Environment, select_autoescape
-
 from render_engine.collection import Collection
 from render_engine.engine import (
     render_engine_templates_loader,

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,5 +1,4 @@
 import pytest
-
 from render_engine.archive import Archive
 from render_engine.collection import Collection
 from render_engine.page import Page

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -57,12 +57,8 @@ def test_archive_num_of_pages(_items_per_page: int, num_of_pages: int):
     assert list(collection.archives)[0].template_vars["num_of_pages"] == num_of_pages
 
     if _items_per_page < 1:
-        assert (
-            list(collection.archives)[1].template_vars["num_of_pages"] == num_of_pages
-        )
-        assert (
-            list(collection.archives)[2].template_vars["num_of_pages"] == num_of_pages
-        )
+        assert list(collection.archives)[1].template_vars["num_of_pages"] == num_of_pages
+        assert list(collection.archives)[2].template_vars["num_of_pages"] == num_of_pages
 
 
 def test_archive_template_is_archive_html():

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -2,10 +2,9 @@ import pathlib
 
 import pluggy
 import pytest
-from render_engine_parser import BasePageParser
-
 from render_engine.collection import Collection
 from render_engine.page import Page
+from render_engine_parser import BasePageParser
 
 pm = pluggy.PluginManager("fake_test")
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,7 +2,6 @@ import datetime
 
 import jinja2
 import pytest
-
 from render_engine.engine import format_datetime
 
 

--- a/tests/test_feeds/conftest_feed.py
+++ b/tests/test_feeds/conftest_feed.py
@@ -37,7 +37,5 @@ def feed_test_site(tmp_path):
         routes = ["feed"]
 
     feed = site.route_list["testcollection"].feed
-    feed_content = feed._render_content(
-        engine=site.theme_manager.engine, SITE_URL="http://localhost:8000"
-    )
+    feed_content = feed._render_content(engine=site.theme_manager.engine, SITE_URL="http://localhost:8000")
     return feed_content

--- a/tests/test_feeds/conftest_feed.py
+++ b/tests/test_feeds/conftest_feed.py
@@ -1,5 +1,4 @@
 import pytest
-
 from render_engine import Collection, Page, Site
 from render_engine.feeds import RSSFeed
 

--- a/tests/test_feeds/test_feeds.py
+++ b/tests/test_feeds/test_feeds.py
@@ -47,10 +47,7 @@ def test_rss_feed_item_url(feed_test_site):
 
 def test_rss_feed_item_has_guid(feed_test_site):
     """Test that the feed item url is set correctly"""
-    assert (
-        '<guid isPermaLink="true">http://localhost:8000/page.html</guid>'
-        in feed_test_site
-    )
+    assert '<guid isPermaLink="true">http://localhost:8000/page.html</guid>' in feed_test_site
 
 
 @pytest.mark.skip("Invalid Test")

--- a/tests/test_feeds/test_feeds.py
+++ b/tests/test_feeds/test_feeds.py
@@ -4,7 +4,6 @@ import pluggy
 import pytest
 from conftest_feed import feed_test_site
 from jinja2 import StrictUndefined
-
 from render_engine.collection import Collection
 from render_engine.feeds import RSSFeed
 from render_engine.page import Page

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -2,7 +2,6 @@ import pathlib
 
 import jinja2
 import pytest
-
 from render_engine import Page
 
 

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -42,9 +42,7 @@ def test_page_from_template(tmp_path: pathlib.Path):
         title = "Test Page"
         template = "test.html"
 
-    environment = jinja2.Environment(
-        loader=jinja2.DictLoader({"test.html": "{{ title }}"})
-    )
+    environment = jinja2.Environment(loader=jinja2.DictLoader({"test.html": "{{ title }}"}))
 
     page = CustomPage()
     assert page._render_content(engine=environment) == "Test Page"
@@ -70,7 +68,4 @@ def test_rendered_page_from_template_has_attributes():
     class CustomPage(Page):
         template = environment.get_template("test.html")
 
-    assert (
-        CustomPage()._render_from_template(template=CustomPage.template)
-        == "CustomPage-custompage-/custompage.html"
-    )
+    assert CustomPage()._render_from_template(template=CustomPage.template) == "CustomPage-custompage-/custompage.html"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -75,18 +75,13 @@ def site(tmp_path_factory):
 
 def test_plugin_is_registered(site: Site):
     """Check that the plugin is registered"""
-    assert [
-        site.plugin_manager._pm.get_name(x) for x in site.plugin_manager.plugins
-    ] == ["FakePlugin"]
+    assert [site.plugin_manager._pm.get_name(x) for x in site.plugin_manager.plugins] == ["FakePlugin"]
 
 
 def test_pages_in_collection_inherit_pugins(site: Site):
     """Check that collection plugins are inherited by pages in the collection"""
 
-    assert (
-        site.route_list["fakecollection"].plugin_manager._pm.list_name_plugin()[0][0]
-        == "FakePlugin"
-    )
+    assert site.route_list["fakecollection"].plugin_manager._pm.list_name_plugin()[0][0] == "FakePlugin"
 
 
 def test_page_ignores_plugin(site: Site):
@@ -97,20 +92,14 @@ def test_page_ignores_plugin(site: Site):
 
 def test_collection_ignores_plugin(site):
     """Check that the plugin is not registered in the collection if it is ignored"""
-    assert (
-        site.route_list["ignoredplugincollection"].plugin_manager._pm.list_name_plugin()
-        == []
-    )
+    assert site.route_list["ignoredplugincollection"].plugin_manager._pm.list_name_plugin() == []
 
 
 def test_collection_archive_inherits_plugins(site: Site, mocker):
     """Check that the archive inherits the pludef test_plugin_render_content_runs_from_archive(site, mocker):
     gins from the collection"""
 
-    assert (
-        site.route_list["fakecollection"].plugin_manager._pm.list_name_plugin()[0][0]
-        == "FakePlugin"
-    )
+    assert site.route_list["fakecollection"].plugin_manager._pm.list_name_plugin()[0][0] == "FakePlugin"
 
 
 def test_collection_archive_runs_render_content_calls(site, mocker):
@@ -171,9 +160,5 @@ def test_collection_default_empty_plugin_setting(site: Site):
 def test_collection_override_default_plugin_setting(site: Site):
     """Asserts that the collection default plugin settings are overridden"""
 
-    site.route_list["fakecollection"].plugin_settings = {
-        "FakePlugin": {"test2": "override2"}
-    }
-    assert site.route_list["fakecollection"].plugin_settings.get("FakePlugin") == {
-        "test2": "override2"
-    }
+    site.route_list["fakecollection"].plugin_settings = {"FakePlugin": {"test2": "override2"}}
+    assert site.route_list["fakecollection"].plugin_settings.get("FakePlugin") == {"test2": "override2"}

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -2,7 +2,6 @@ import importlib
 import typing
 
 import pytest
-
 from render_engine.collection import Collection
 from render_engine.page import Page
 from render_engine.plugins import PluginManager, hook_impl

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import pluggy
 import pytest
 from jinja2 import DictLoader, FileSystemLoader
-
 from render_engine.collection import Collection
 from render_engine.page import Page
 from render_engine.plugins import SiteSpecs

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -84,9 +84,7 @@ def test_site_collection_in_route_list(site):
 
     assert site.route_list["collection"] == collection
     assert len(site.route_list) == 1
-    assert "custompage1" in [
-        getattr(page, page._reference) for page in site.route_list["collection"]
-    ]
+    assert "custompage1" in [getattr(page, page._reference) for page in site.route_list["collection"]]
 
 
 def test_site_page_with_multiple_routes_has_one_entry_in_routes_list(site):
@@ -123,9 +121,7 @@ def test_collection_archive_in_route_list(site, tmp_path: Path):
     test_collection_archive_template.write_text("This is the collection archive")
 
     test_collection_template = Path(tmp_path / "collection_archive_item_template.html")
-    test_collection_template.write_text(
-        "The collection archive route is at '{{ 'customcollection' |url_for }}'"
-    )
+    test_collection_template.write_text("The collection archive route is at '{{ 'customcollection' |url_for }}'")
 
     site.theme_manager.engine.loader.loaders.insert(0, FileSystemLoader(tmp_path))
 
@@ -141,10 +137,7 @@ def test_collection_archive_in_route_list(site, tmp_path: Path):
     site.render()
     assert site.output_path.joinpath("customcollection.html").exists()
     assert site.output_path.joinpath("customcollectionpage.html").exists()
-    assert (
-        site.output_path.joinpath("customcollection.html").read_text()
-        == "This is the collection archive"
-    )
+    assert site.output_path.joinpath("customcollection.html").read_text() == "This is the collection archive"
     assert (
         site.output_path.joinpath("customcollectionpage.html").read_text()
         == "The collection archive route is at '/customcollection.html'"
@@ -153,9 +146,7 @@ def test_collection_archive_in_route_list(site, tmp_path: Path):
 
 @pytest.fixture(scope="module")
 def site_with_collection(tmp_path_factory: pytest.TempPathFactory):
-    collection_archive_path = (
-        tmp_path_factory.getbasetemp() / "collection_archive_items"
-    )
+    collection_archive_path = tmp_path_factory.getbasetemp() / "collection_archive_items"
     collection_archive_output_path = collection_archive_path / "output"
     static_tmp_dir = collection_archive_path / "static"
     static_tmp_dir.mkdir(parents=True)
@@ -192,10 +183,7 @@ def test_collection_archives_generates_by_items_per_page(site_with_collection: S
         2: second page item
     """
 
-    assert (
-        len(list(site_with_collection.route_list["custompagescollection"].archives))
-        == 3
-    )
+    assert len(list(site_with_collection.route_list["custompagescollection"].archives)) == 3
 
 
 def test_collection_archive_pages_in_route_list(site_with_collection: Site):
@@ -210,9 +198,7 @@ def test_url_for_Collection_in_site(site: Site, tmp_path: Path):
     Tests that url_for a page in a collection is added to a template
     """
     test_template = Path(tmp_path / "custom_template.html")
-    test_template.write_text(
-        "The URL is '{{ 'customcollection.customcollectionpage' | url_for }}'"
-    )
+    test_template.write_text("The URL is '{{ 'customcollection.customcollectionpage' | url_for }}'")
     if site.theme_manager.engine.loader is not None:
         site.theme_manager.engine.loader.loaders.insert(0, FileSystemLoader(tmp_path))
 

--- a/tests/test_templates/test_base_html.py
+++ b/tests/test_templates/test_base_html.py
@@ -33,10 +33,7 @@ def test_base_html_body_class(theme_site):
     theme_site.register_themes(bodyClassTheme)
     theme_site._render_output("./", theme_site.route_list["testpage"])
 
-    assert (
-        '<body class="my-class">'
-        in (theme_site.output_path / "testpage.html").read_text()
-    )
+    assert '<body class="my-class">' in (theme_site.output_path / "testpage.html").read_text()
 
 
 def test_base_html_head_include(theme_site):
@@ -53,10 +50,7 @@ def test_base_html_head_include(theme_site):
     theme_site.load_themes()
     theme_site._render_output("./", theme_site.route_list["testpage"])
 
-    assert (
-        "<script>console.log('test')</script>"
-        in (theme_site.output_path / "testpage.html").read_text()
-    )
+    assert "<script>console.log('test')</script>" in (theme_site.output_path / "testpage.html").read_text()
 
 
 def test_base_html_head_reload_theme_count(theme_site):

--- a/tests/test_templates/test_base_html.py
+++ b/tests/test_templates/test_base_html.py
@@ -1,6 +1,5 @@
 import pytest
 from jinja2 import DictLoader
-
 from render_engine.page import Page
 from render_engine.site import Site
 from render_engine.themes import Theme

--- a/tests/test_theme_manager.py
+++ b/tests/test_theme_manager.py
@@ -33,9 +33,7 @@ def test_ThemeManager_registers_theme():
     )
 
     thememgr = ThemeManager(
-        engine=Environment(
-            loader=ChoiceLoader([FileSystemLoader("templates"), PrefixLoader({})])
-        ),
+        engine=Environment(loader=ChoiceLoader([FileSystemLoader("templates"), PrefixLoader({})])),
         output_path="test",
     )
     for x in (loader2theme, loader3theme, loader4theme):

--- a/tests/test_theme_manager.py
+++ b/tests/test_theme_manager.py
@@ -1,6 +1,5 @@
 from jinja2.environment import Environment
 from jinja2.loaders import ChoiceLoader, DictLoader, FileSystemLoader, PrefixLoader
-
 from render_engine.themes import Theme, ThemeManager
 
 

--- a/tests/tests_cli/test_render_engine_cli.py
+++ b/tests/tests_cli/test_render_engine_cli.py
@@ -25,9 +25,7 @@ def site(tmp_path_factory):
 
 @pytest.fixture(scope="module")
 def event_handler(site):
-
     class Handler(ServerEventHandler):
-
         def stop_watcher(self):  # Stop the
             time.sleep(2)
             return True

--- a/tests/tests_cli/test_render_engine_cli.py
+++ b/tests/tests_cli/test_render_engine_cli.py
@@ -1,0 +1,61 @@
+import time
+
+import httpx
+import pytest
+from render_engine.cli.event import ServerEventHandler
+from render_engine.page import Page
+from render_engine.site import Site
+
+
+@pytest.fixture(scope="module")
+def site(tmp_path_factory):
+    """Base Site Object"""
+
+    test_site = Site()
+    test_output_path = tmp_path_factory.mktemp("output")
+    test_site.output_path = test_output_path
+
+    @test_site.page
+    class Index(Page):
+        content = "Hello World!"
+
+    test_site.render()
+    return test_site
+
+
+@pytest.fixture(scope="module")
+def event_handler(site):
+
+    class Handler(ServerEventHandler):
+
+        def stop_watcher(self):  # Stop the
+            time.sleep(2)
+            return True
+
+    handler = Handler(
+        server_address=("localhost", 8000),
+        dir_to_serve=site.output_path,
+        import_path="tests.tests_cli.test_render_engine_cli",
+        site=site,
+        dirs_to_watch=None,
+    )
+
+    return handler
+
+
+def test_server_build(event_handler):
+    """Asserts you can start and stop the server"""
+    event_handler.start_server()
+    response = httpx.get("http://localhost:8000")
+    event_handler.stop_server()
+    assert response.status_code == 200
+    assert response.text == "Hello World!"
+
+
+# @pytest.mark.skip("This cannot be tested with pytest")
+def test_as_a_context_manager(event_handler):
+    """Asserts you can start and stop the server with a context manager"""
+    with event_handler:
+        response = httpx.get("http://localhost:8000")
+        assert response.status_code == 200
+        assert response.text

--- a/tests/tests_cli/test_render_engine_init.py
+++ b/tests/tests_cli/test_render_engine_init.py
@@ -1,5 +1,4 @@
 import pytest
-
 from render_engine.cli import cli
 
 

--- a/tests/tests_cli/test_render_engine_init.py
+++ b/tests/tests_cli/test_render_engine_init.py
@@ -6,9 +6,7 @@ from render_engine.cli import cli
 def test_template(tmp_path_factory):
     test_template = tmp_path_factory.getbasetemp().joinpath("test_template")
     test_template.mkdir()
-    test_template.joinpath("cookiecutter.json").write_bytes(
-        b'{"project_slug": "test_template"}'
-    )
+    test_template.joinpath("cookiecutter.json").write_bytes(b'{"project_slug": "test_template"}')
     cc_path = test_template.joinpath("{{cookiecutter.project_slug}}")
     cc_path.mkdir()
     cc_path.joinpath("app.py").write_bytes(


### PR DESCRIPTION
resolves #728, #729

- rename variable of Site object in cli `app` to `site`
- implements watchfiles
- creates `get_site_content_paths` to set reload on all content_paths 
- implements a context_manager for the cli
- creates `stop_watcher` method to allow for simpler testing
- implements tests for start_server/stop_server


<!--
SUMMARY OF THE CHANGES BEING MADE
Be sure to include any referenced issues and discussions.
-->

# Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [X] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [X] :hammer_and_wrench: (Refactor)

## Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

## Changes have been Tested

- [X] YES - Changes have been tested

## Next Steps

<!--ANY FURTHER STEPS TO BE TAKEN-->
