### PR TITLE
Run Dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,11 @@ updates:
         versions: ["3.4.x"]
     # Check the pypi registry for updates every day (weekdays)
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
Changing Interval of schedule from weekly to monthly

In dependabot.yml, the the workflow is scheduled weekly. To make the workflow only run once a month, I have changed the schedule to be monthly. This will run first of every month.

# Type of Issue
- [x] :arrow_up: (Update)

#770 
