### PR TITLE
777 remove dir to serve from spawn server 2

### DIFF
--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -278,8 +278,6 @@ def serve(
         remove_output_folder(Path(site.output_path))
     site.render()
 
-    directory = str(site.output_path)
-
     server_address = ("127.0.0.1", port)
 
     handler = ServerEventHandler(

--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -20,7 +20,9 @@ app = typer.Typer()
 def get_site_content_paths(site: Site) -> list[Path | None]:
     """Get the content paths from the route_list in the Site"""
 
-    base_paths = map(lambda x: getattr(x, "content_path", None), site.route_list.values())
+    base_paths = map(
+        lambda x: getattr(x, "content_path", None), site.route_list.values()
+    )
     return list(filter(lambda x: x is not None, base_paths))
 
 
@@ -59,7 +61,9 @@ def get_available_themes(console: Console, site: Site, theme_name: str) -> list[
         return []
 
 
-def display_filtered_templates(title: str, templates_list: list[str], filter_value: str) -> None:
+def display_filtered_templates(
+    title: str, templates_list: list[str], filter_value: str
+) -> None:
     """Display filtered templates based on a given filter value."""
     table = Table(title=title)
     table.add_column("[bold blue]Templates[bold blue]")
@@ -72,8 +76,12 @@ def display_filtered_templates(title: str, templates_list: list[str], filter_val
 @app.command()
 def templates(
     module_site: Annotated[tuple[str, str], typer.Argument(callback=split_module_site)],
-    theme_name: Annotated[str, typer.Option("--theme-name", help="Theme to search templates in")] = "",
-    filter_value: Annotated[str, typer.Option("--filter-value", help="Filter templates based on names")] = "",
+    theme_name: Annotated[
+        str, typer.Option("--theme-name", help="Theme to search templates in")
+    ] = "",
+    filter_value: Annotated[
+        str, typer.Option("--filter-value", help="Filter templates based on names")
+    ] = "",
 ):
     """
     CLI for listing available theme templates.
@@ -96,7 +104,9 @@ def templates(
                 filter_value,
             )
     else:
-        console.print("[red]No theme name specified. Listing all installed themes and their templates[red]")
+        console.print(
+            "[red]No theme name specified. Listing all installed themes and their templates[red]"
+        )
         for theme_prefix, theme_loader in site.theme_manager.prefix.items():
             templates_list = theme_loader.list_templates()
             display_filtered_templates(
@@ -123,7 +133,9 @@ def init(
         ]
         | None
     ) = None,
-    no_input: Annotated[bool, typer.Option("--no-input", help="Do not prompt for parameters")] = False,
+    no_input: Annotated[
+        bool, typer.Option("--no-input", help="Do not prompt for parameters")
+    ] = False,
     output_dir: Annotated[
         Path,
         typer.Option(
@@ -133,7 +145,9 @@ def init(
             exists=True,
         ),
     ] = Path("./"),
-    cookiecutter_args: Annotated[Path, typer.Option(callback=lambda x: json.loads(x))] = {},
+    cookiecutter_args: Annotated[
+        Path, typer.Option(callback=lambda x: json.loads(x))
+    ] = {},
 ) -> None:
     """
     Create a new site configuration. You can provide extra_context to the cookiecutter template.
@@ -271,7 +285,6 @@ def serve(
     handler = ServerEventHandler(
         import_path=module,
         server_address=server_address,
-        dir_to_serve=directory,
         dirs_to_watch=get_site_content_paths(site) if reload else None,
         site=site,
         patterns=None,

--- a/src/render_engine/cli/event.py
+++ b/src/render_engine/cli/event.py
@@ -11,7 +11,9 @@ from render_engine import Site
 console = Console()
 
 
-def spawn_server(server_address: tuple[str, int], directory: str) -> ThreadingHTTPServer:
+def spawn_server(
+    server_address: tuple[str, int], directory: str
+) -> ThreadingHTTPServer:
     """
         Create and return an instance of ThreadingHTTPServer that serves files
     from the specified directory.
@@ -34,7 +36,7 @@ def spawn_server(server_address: tuple[str, int], directory: str) -> ThreadingHT
 class ServerEventHandler:
     """
     Initializes a handler that looks for file changes in a directory (`dirs_to_watch`), as
-    well as creates a server to serve files in a given directory (`dir_to_serve`). The
+    well as creates a server to serve files in a given directory. The
     class contains helper methods to manage server events in a thread.
 
     Meanwhile, the `watch` method uses an instance of this handler class to monitor for file
@@ -44,7 +46,6 @@ class ServerEventHandler:
 
     Params:
         server_address: A tuple of the form (host, port)
-        dir_to_serve: The directory to serve
         site: A Site instance
         dirs_to_watch: The directories to watch
         patterns: A list of regular expressions to filter files
@@ -106,7 +107,7 @@ class ServerEventHandler:
 
     def watch(self) -> None:
         """
-        This function `watch` starts the server on the output path (`dir_to_serve`)
+        This function `watch` starts the server on the output path
         and monitors the specified directories in (`dirs_to_watch`) for changes.
 
         After it starts the server, it "waits" and monitors the directory for

--- a/tests/tests_cli/test_render_engine_cli.py
+++ b/tests/tests_cli/test_render_engine_cli.py
@@ -2,7 +2,6 @@ import time
 
 import httpx
 import pytest
-
 from render_engine.cli.event import ServerEventHandler
 from render_engine.page import Page
 from render_engine.site import Site
@@ -33,7 +32,6 @@ def event_handler(site):
 
     handler = Handler(
         server_address=("localhost", 8000),
-        dir_to_serve=site.output_path,
         import_path="tests.tests_cli.test_render_engine_cli",
         site=site,
         dirs_to_watch=None,


### PR DESCRIPTION
<!--
SUMMARY OF THE CHANGES BEING MADE
Be sure to include any referenced issues and discussions.
-->

Removes the `dir_to_serve` replacing it with `site.output_path`
#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [X] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

## Changes have been Documented (If Applicable)

- [X] YES - Changes have been documented

## Changes have been Tested

- [X] YES - Changes have been tested

## Next Steps

<!--ANY FURTHER STEPS TO BE TAKEN-->
