### PR TITLE
fix: adjust heading levels in PR template for accessibility

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ SUMMARY OF THE CHANGES BEING MADE
 Be sure to include any referenced issues and discussions.
 -->
 
-# Type of Issue
+#### Type of Issue
 
 - [ ] :bug: (bug)
 - [ ] :book: (Documentation)
@@ -13,14 +13,14 @@ Be sure to include any referenced issues and discussions.
 - [ ] :no_entry_sign: (Removal)
 - [ ] :hammer_and_wrench: (Refactor)
 
-## Changes have been Documented (If Applicable)
+#### Changes have been Documented (If Applicable)
 
 - [ ] YES - Changes have been documented
 
-## Changes have been Tested
+#### Changes have been Tested
 
 - [ ] YES - Changes have been tested
 
-## Next Steps
+#### Next Steps
 
 <!--ANY FURTHER STEPS TO BE TAKEN-->


### PR DESCRIPTION
Changed heading levels from H1/H2 to H4 in the PULL_REQUEST_TEMPLATE.md to maintain consistency with GitHub’s default H3 headings. This improves accessibility for screen readers by providing a logical heading structure.

<!--
SUMMARY OF THE CHANGES BEING MADE
Be sure to include any referenced issues and discussions.
-->

# Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

## Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

## Changes have been Tested

- [ ] YES - Changes have been tested

## Next Steps

<!--ANY FURTHER STEPS TO BE TAKEN-->
