### PR TITLE
Sorts the RSS Feeds based on Collection Settings 

### DIFF
--- a/src/render_engine/blog.py
+++ b/src/render_engine/blog.py
@@ -31,9 +31,9 @@ class Blog(Collection):
     """
 
     BasePageParser = MarkdownPageParser
-    sort_reverse: bool = True
     sort_by = "date"
     has_archive = True
+    sort_reverse = True
 
     @staticmethod
     def _metadata_attrs(**kwargs) -> dict[str, Any]:

--- a/src/render_engine/collection.py
+++ b/src/render_engine/collection.py
@@ -102,9 +102,7 @@ class Collection(BaseObject):
 
     def iter_content_path(self):
         """Iterate through in the collection's content path."""
-        return flatten(
-            [Path(self.content_path).glob(suffix) for suffix in self.include_suffixes]
-        )
+        return flatten([Path(self.content_path).glob(suffix) for suffix in self.include_suffixes])
 
     def _generate_content_from_modified_pages(
         self,

--- a/src/render_engine/collection.py
+++ b/src/render_engine/collection.py
@@ -102,7 +102,9 @@ class Collection(BaseObject):
 
     def iter_content_path(self):
         """Iterate through in the collection's content path."""
-        return flatten([Path(self.content_path).glob(suffix) for suffix in self.include_suffixes])
+        return flatten(
+            [Path(self.content_path).glob(suffix) for suffix in self.include_suffixes]
+        )
 
     def _generate_content_from_modified_pages(
         self,
@@ -191,7 +193,7 @@ class Collection(BaseObject):
     @property
     def feed(self):
         feed = self.Feed()
-        feed.pages = [page for page in self]
+        feed.pages = self.sorted_pages
         feed.title = getattr(self, "feed_title", self._title)
         feed.slug = self._slug
         feed.Parser = self.Parser

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -1,6 +1,27 @@
+import pytest
 import datetime
 
+from render_engine.page import Page
 from render_engine.blog import Blog
+
+
+@pytest.fixture()
+def blog_with_pages():
+
+    class Page1(Page):
+        title = "Older Blog Post"
+        date = datetime.datetime(2024, 1, 1)
+        content = """Newer Page"""
+
+    class Page2(Page):
+        title = "Newer Blog Post"
+        date = datetime.datetime(2024, 1, 2)
+        content = """Newer Page"""
+
+    class CustomBlog(Blog):
+        pages = [Page1, Page2]
+
+    return CustomBlog()
 
 
 def test_blog_has_feed():
@@ -15,3 +36,16 @@ def test_blog_metadata():
     assert metadata["title"] == "Untitled Entry"
     # metadata should have date now
     assert isinstance(metadata["date"], datetime.datetime)
+
+
+def test_blog_sorted_pages_is_in_reverse(blog_with_pages):
+    assert [page.title for page in blog_with_pages.sorted_pages] == [
+        "Newer Blog Post",
+        "Older Blog Post",
+    ]
+
+
+def test_blog_feed_is_sorted_in_reverse(blog_with_pages):
+    """#838 Newest Blog Posts should be listed first to conform with many services that don't retrieve all the posts"""
+
+    assert blog_with_pages.feed.pages[0].title == "Newer Blog Post"

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -1,13 +1,13 @@
-import pytest
 import datetime
 
-from render_engine.page import Page
+import pytest
+
 from render_engine.blog import Blog
+from render_engine.page import Page
 
 
 @pytest.fixture()
 def blog_with_pages():
-
     class Page1(Page):
         title = "Older Blog Post"
         date = datetime.datetime(2024, 1, 1)


### PR DESCRIPTION
<!--
SUMMARY OF THE CHANGES BEING MADE
Be sure to include any referenced issues and discussions.
-->

#### Type of Issue

- [X] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

#### Changes have been Tested

- [x] YES - Changes have been tested

#### Next Steps

Some RSS Readers are not working with Render Engine posts due to truncating the items list to the first `n` items.

Jekyll and Django both get around this with their feeds having the most recent content on top.

This change does that by making the feed pages pull from `sorted_pages`` (also used in the  `archive` object and the `latest` method) instead of iterating through pages.

This means that this functionality can be overridden if you manually set `_sort_reverse`.

<!--ANY FURTHER STEPS TO BE TAKEN-->
