### PR TITLE
add auto labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,43 @@
+# Add 'root' label to any root file changes
+# Quotation marks are required for the leading asterisk
+root:
+- changed-files:
+  - any-glob-to-any-file: '*'
+
+# Add 'documentation' label to any file changes within 'docs' or 'guides' folders
+# Add 'documentation' label to any change to .md files within the entire repository
+documentation:
+- changed-files:
+  - any-glob-to-any-file: ['docs/**', 'guides/**']
+  - any-glob-to-any-file: '**/*.md'
+
+# Add 'source' label to any change to src files within the source dir EXCEPT for the docs sub-folder
+source:
+- all:
+  - changed-files:
+    - any-glob-to-any-file: 'src/**/*'
+    - all-globs-to-all-files: '!src/docs/*'
+
+# Add 'feature' label to any PR where the head branch name starts with `feature` or has a `feature` section in the name
+feature:
+ - head-branch: ['^feature', 'feature', 'feat', '^feat']
+
+bug:
+ - head-branch: ['^fix', 'fix', '^bug', 'bug', '^issue', 'issue']
+
+github-actions:
+ - changed-files:
+   - any-glob-to-any-file: '.github/workflows/**'
+
+dev-tools:
+  - changed-files:
+    - any-glob-to-any-file: '.vscode/**'
+    - any-glob-to-any-file: '.devcontainer/**'
+
+cli:
+  - changed-files:
+    - any-glob-to-any-file: 'src/render_engine/cli/**'
+
+python:
+- changed-files:
+  - any-glob-to-any-file: '**/*.py'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,16 @@
+name: Pull Request Labeler
+
+on:
+  workflow_dispatch:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/labeler@v5


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions configuration to automate the labeling of pull requests based on specific criteria.

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [x] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [-] YES - Changes have been documented

#### Changes have been Tested

- [-] YES - Changes have been tested

