### PR TITLE
removes default value and changes sort to _title

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-    python: python3.12
+  python: python3.12
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,47 +9,39 @@ description = "A Flexible Static Site Generator for Python"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "gitpython",
-    "jinja2",
-    "markdown2",
-    "more-itertools",
-    "pluggy",
-    "python-dateutil",
-    "python-frontmatter",
-    "python-slugify",
-    "render-engine-parser",
-    "render-engine-markdown",
-    "tzdata",
+  "gitpython",
+  "jinja2",
+  "markdown2",
+  "more-itertools",
+  "pluggy",
+  "python-dateutil",
+  "python-frontmatter",
+  "python-slugify",
+  "render-engine-parser",
+  "render-engine-markdown",
 ]
 
 [project.optional-dependencies]
-cli = [
-    "cookiecutter",
-    "rich",
-    "typer",
-    "watchfiles",
-]
-extras = [
-  "render-engine-sitemap"
-]
+cli = ["cookiecutter", "rich", "typer", "watchfiles"]
+extras = ["render-engine-sitemap"]
 dev = [
-    "cookiecutter",
-    "ephemeral-port-reserve",
-    "httpx",
-    "mkdocs",
-    "mkdocs-material",
-    "mkdocstrings[python]",
-    "mypy",
-    "pre-commit",
-    "pymdown-extensions",
-    "pytest",
-    "pytest-cov",
-    "pytest-mock",
-    "rich",
-    "ruff",
-    "typer",
-    "watchfiles",
-    ]
+  "cookiecutter",
+  "ephemeral-port-reserve",
+  "httpx",
+  "mkdocs",
+  "mkdocs-material",
+  "mkdocstrings[python]",
+  "mypy",
+  "pre-commit",
+  "pymdown-extensions",
+  "pytest",
+  "pytest-cov",
+  "pytest-mock",
+  "rich",
+  "ruff",
+  "typer",
+  "watchfiles",
+]
 
 
 [tool.setuptools_scm]

--- a/src/render_engine/blog.py
+++ b/src/render_engine/blog.py
@@ -1,8 +1,3 @@
-import datetime
-import os
-import zoneinfo
-from typing import Any
-
 from render_engine_markdown import MarkdownPageParser
 
 from .collection import Collection

--- a/src/render_engine/blog.py
+++ b/src/render_engine/blog.py
@@ -35,19 +35,6 @@ class Blog(Collection):
     has_archive = True
     sort_reverse = True
 
-    @staticmethod
-    def _metadata_attrs(**kwargs) -> dict[str, Any]:
-        timezone = zoneinfo.ZoneInfo(
-            os.environ.get(
-                "RENDER_ENGINE_DEFAULT_TIMEZONE",
-                "UTC",
-            )
-        )
-        return {
-            **Collection._metadata_attrs(),
-            **{"date": datetime.datetime.now(tz=timezone)},
-        }
-
     def latest(self, count: int = 1) -> list[Collection]:
         """Get the latest post from the collection."""
         latest_pages = list(

--- a/src/render_engine/collection.py
+++ b/src/render_engine/collection.py
@@ -102,9 +102,7 @@ class Collection(BaseObject):
 
     def iter_content_path(self):
         """Iterate through in the collection's content path."""
-        return flatten(
-            [Path(self.content_path).glob(suffix) for suffix in self.include_suffixes]
-        )
+        return flatten([Path(self.content_path).glob(suffix) for suffix in self.include_suffixes])
 
     def _generate_content_from_modified_pages(
         self,

--- a/src/render_engine/collection.py
+++ b/src/render_engine/collection.py
@@ -77,7 +77,7 @@ class Collection(BaseObject):
     parser_extras: dict[str, Any]
     required_themes: list[Callable]
     routes: list[str | Path] = ["./"]
-    sort_by: str = "title"
+    sort_by: str = "_title"
     sort_reverse: bool = False
     template_vars: dict[str, Any]
     template: str | None
@@ -102,7 +102,9 @@ class Collection(BaseObject):
 
     def iter_content_path(self):
         """Iterate through in the collection's content path."""
-        return flatten([Path(self.content_path).glob(suffix) for suffix in self.include_suffixes])
+        return flatten(
+            [Path(self.content_path).glob(suffix) for suffix in self.include_suffixes]
+        )
 
     def _generate_content_from_modified_pages(
         self,
@@ -146,7 +148,7 @@ class Collection(BaseObject):
     def sorted_pages(self):
         return sorted(
             (page for page in self.__iter__()),
-            key=lambda page: getattr(page, self.sort_by, self._title),
+            key=lambda page: getattr(page, self.sort_by),
             reverse=self.sort_reverse,
         )
 

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -31,7 +31,7 @@ def test_blog_has_feed():
     assert hasattr(blog, "Feed")
 
 
-def test_blog_post_must_have_date():
+def test_sorting_blog_posts_with_no_date_raises_error():
     """
     Tests that blog posts that don't have date attributes
     raise an error when trying to sort

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -33,9 +33,7 @@ def blog_with_time_zones():
 
     class Page2(Page):
         title = "Newer Blog Post"
-        date = datetime.datetime(
-            2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=-1))
-        )
+        date = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=-1)))
         content = """Newer Page"""
 
     class CustomBlog(Blog):

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -24,31 +24,19 @@ def blog_with_pages():
     return CustomBlog()
 
 
-@pytest.fixture()
-def blog_with_time_zones():
-    class Page1(Page):
-        title = "Older Blog Post"
-        date = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
-        content = """Older Page"""
-
-    class Page2(Page):
-        title = "Newer Blog Post"
-        date = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=-1)))
-        content = """Newer Page"""
-
-    class CustomBlog(Blog):
-        pages = [Page1, Page2]
-
-    return CustomBlog()
-
-
 def test_blog_has_feed():
     """Tests that the Blog class has a Feed attribute."""
+
     blog = Blog()
     assert hasattr(blog, "Feed")
 
 
 def test_blog_post_must_have_date():
+    """
+    Tests that blog posts that don't have date attributes
+    raise an error when trying to sort
+    """
+
     class Page1(Page):
         title = "Older Blog Post"
         content = """Older Page"""
@@ -64,7 +52,6 @@ def test_blog_post_must_have_date():
 
     with pytest.raises(AttributeError):
         print(blog.sorted_pages)
-        assert blog.sort_by == "date"
 
 
 def test_blog_sorted_pages_is_in_reverse(blog_with_pages):
@@ -75,6 +62,9 @@ def test_blog_sorted_pages_is_in_reverse(blog_with_pages):
 
 
 def test_blog_feed_is_sorted_in_reverse(blog_with_pages):
-    """#838 Newest Blog Posts should be listed first to conform with many services that don't retrieve all the posts"""
+    """
+    Newest Blog Posts should be listed first to
+    conform with many services that don't retrieve all the posts
+    """
 
     assert blog_with_pages.feed.pages[0].title == "Newer Blog Post"

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -11,11 +11,31 @@ def blog_with_pages():
     class Page1(Page):
         title = "Older Blog Post"
         date = datetime.datetime(2024, 1, 1)
-        content = """Newer Page"""
+        content = """Older Page"""
 
     class Page2(Page):
         title = "Newer Blog Post"
         date = datetime.datetime(2024, 1, 2)
+        content = """Newer Page"""
+
+    class CustomBlog(Blog):
+        pages = [Page1, Page2]
+
+    return CustomBlog()
+
+
+@pytest.fixture()
+def blog_with_time_zones():
+    class Page1(Page):
+        title = "Older Blog Post"
+        date = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
+        content = """Older Page"""
+
+    class Page2(Page):
+        title = "Newer Blog Post"
+        date = datetime.datetime(
+            2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=-1))
+        )
         content = """Newer Page"""
 
     class CustomBlog(Blog):
@@ -30,12 +50,23 @@ def test_blog_has_feed():
     assert hasattr(blog, "Feed")
 
 
-def test_blog_metadata():
-    metadata = Blog._metadata_attrs()
-    # title should not be affected
-    assert metadata["title"] == "Untitled Entry"
-    # metadata should have date now
-    assert isinstance(metadata["date"], datetime.datetime)
+def test_blog_post_must_have_date():
+    class Page1(Page):
+        title = "Older Blog Post"
+        content = """Older Page"""
+
+    class Page2(Page):
+        title = "Newer Blog Post"
+        content = """Newer Page"""
+
+    class CustomBlog(Blog):
+        pages = [Page1, Page2]
+
+    blog = CustomBlog()
+
+    with pytest.raises(AttributeError):
+        print(blog.sorted_pages)
+        assert blog.sort_by == "date"
 
 
 def test_blog_sorted_pages_is_in_reverse(blog_with_pages):


### PR DESCRIPTION
<!--
SUMMARY OF THE CHANGES BEING MADE
Be sure to include any referenced issues and discussions.
-->

Removes the default value for iterating through `sorted_pages`

Fixing this revealed a new bug instead of defaulting to `title` which is defined,
it should default to `_title` which will default ultimately.

#### Type of Issue

- [x] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

#### Changes have been Tested

- [x] YES - Changes have been tested

#### Next Steps

# 877 will add better error message around this
<!--ANY FURTHER STEPS TO BE TAKEN-->
