### PR TITLE
Fix issue with `title` in `new-entry`

### DIFF
--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -329,13 +329,15 @@ def new_entry(
     """Creates a new collection entry based on the parser. Entries are added to the Collections content_path"""
     module, site_name = split_module_site(module_site)
     parsed_args = split_args(args) if args else {}
-    # There is an issue with including `title` in the context to the parser that causes an exception. We can fix this by popping it out of the arguments here and using regex to push it back in later.
+    # There is an issue with including `title` in the context to the parser that causes an exception. We can fix
+    # this by popping it out of the arguments here and using regex to push it back in later.
     title = parsed_args.pop("title", None)
     site = get_site(module, site_name)
     _collection = next(coll for coll in site.route_list.values() if type(coll).__name__.lower() == collection.lower())
     entry = create_collection_entry(content=content, collection=_collection, **parsed_args)
     if title:
-        # If we had a title earlier this is where we replace the default that is added by the template handler with the one supplied by the user.
+        # If we had a title earlier this is where we replace the default that is added by the template handler with
+        # the one supplied by the user.
         entry = re.sub(r'title: Untitled Entry', f'title: {title}', entry)
     filepath = Path(_collection.content_path).joinpath(filename)
     filepath.write_text(entry)

--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -72,13 +72,16 @@ def split_args(args: list[str] | None) -> dict[str, str]:
     split_arguments = {}
     for arg in args:
         # Accept arguments that are split with either `:` or `=`. Raise a ValueError if neither is found
-        split_arg = re.split(r'[:=]', arg, maxsplit=1)
+        split_arg = re.split(r"[:=]", arg, maxsplit=1)
         if len(split_arg) != 2:
-            raise ValueError(f"Invalid argument: {repr(arg)}. Arguments must have the key, value pair separated by either an = or a :")
+            raise ValueError(
+                f"Invalid argument: {repr(arg)}. Arguments must have the "
+                f"key, value pair separated by either an = or a :"
+            )
         k, v = map(str.strip, split_arg)
         if k in split_arguments:
             # Do not allow redefinition of arguments
-            raise ValueError(f'Key {repr(k)} is already defined.')
+            raise ValueError(f"Key {repr(k)} is already defined.")
         split_arguments[k] = v
     return split_arguments
 
@@ -339,7 +342,7 @@ def new_entry(
     if title:
         # If we had a title earlier this is where we replace the default that is added by the template handler with
         # the one supplied by the user.
-        entry = re.sub(r'title: Untitled Entry', f'title: {title}', entry)
+        entry = re.sub(r"title: Untitled Entry", f"title: {title}", entry)
     filepath = Path(_collection.content_path).joinpath(filename)
     filepath.write_text(entry)
     Console().print(f'New {collection} entry created at "{filepath}"')

--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -72,7 +72,8 @@ def split_args(args: list[str] | None) -> dict[str, str]:
     split_arguments = {}
     for arg in args:
         # Accept arguments that are split with either `:` or `=`. Raise a ValueError if neither is found
-        if not (split_arg := re.split(r'[:=]', arg, maxsplit=1)):
+        split_arg = re.split(r'[:=]', arg, maxsplit=1)
+        if len(split_arg) != 2:
             raise ValueError(f"Invalid argument: {repr(arg)}. Arguments must have the key, value pair separated by either an = or a :")
         k, v = map(str.strip, split_arg)
         if k in split_arguments:

--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -1,6 +1,7 @@
 # ruff: noqa: UP007
 import importlib
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -66,7 +67,19 @@ def create_collection_entry(content: str | None, collection: Collection, **conte
 
 
 def split_args(args: list[str] | None) -> dict[str, str]:
-    return {value.split("=")[0]: value.split("=")[1] for value in args if args}
+    if not args:
+        return {}
+    split_arguments = {}
+    for arg in args:
+        # Accept arguments that are split with either `:` or `=`. Raise a ValueError if neither is found
+        if not (split_arg := re.split(r'[:=]', arg, maxsplit=1)):
+            raise ValueError(f"Invalid argument: {repr(arg)}. Arguments must have the key, value pair separated by either an = or a :")
+        k, v = map(str.strip, split_arg)
+        if k in split_arguments:
+            # Do not allow redefinition of arguments
+            raise ValueError(f'Key {repr(k)} is already defined.')
+        split_arguments[k] = v
+    return split_arguments
 
 
 def display_filtered_templates(title: str, templates_list: list[str], filter_value: str) -> None:
@@ -309,16 +322,21 @@ def new_entry(
     args: Annotated[
         Optional[list[str]],
         typer.Option(
-            help="key value attrs to include in your entry use the format `--args key=value`",
+            help="key value attrs to include in your entry use the format `--args key=value` or `--args key:value`",
         ),
     ] = None,
 ):
     """Creates a new collection entry based on the parser. Entries are added to the Collections content_path"""
     module, site_name = split_module_site(module_site)
     parsed_args = split_args(args) if args else {}
+    # There is an issue with including `title` in the context to the parser that causes an exception. We can fix this by popping it out of the arguments here and using regex to push it back in later.
+    title = parsed_args.pop("title", None)
     site = get_site(module, site_name)
     _collection = next(coll for coll in site.route_list.values() if type(coll).__name__.lower() == collection.lower())
     entry = create_collection_entry(content=content, collection=_collection, **parsed_args)
+    if title:
+        # If we had a title earlier this is where we replace the default that is added by the template handler with the one supplied by the user.
+        entry = re.sub(r'title: Untitled Entry', f'title: {title}', entry)
     filepath = Path(_collection.content_path).joinpath(filename)
     filepath.write_text(entry)
     Console().print(f'New {collection} entry created at "{filepath}"')


### PR DESCRIPTION
Addresses Issue #856 
- When `title` is passed to the template renderer it causes an issue because of a duplicate keyword value being passed. Since the duplication actually occurs in an external library this is handled by removing it from the args passed to the creation tools and then updating the rendered file using regex.
- Added validation for `args`
  - Args can be separated by either `:` or `=`
  - Duplicate args are not allowed


#### Type of Issue

- [x] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

#### Changes have been Tested

- [x] YES - Changes have been tested

#### Next Steps

Probably not a bad idea to add some testing for `new_entry`. Since no unit tests existed for this function I didn't add at this point.
