### PR TITLE
Issue 885

### DIFF
--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -345,13 +345,13 @@ def new_entry(
     site = get_site(module, site_name)
     _collection = next(coll for coll in site.route_list.values() if type(coll).__name__.lower() == collection.lower())
     if content and content_file:
-        raise TypeError('Both content and content_file provided. At most one may be provided.')
+        raise TypeError("Both content and content_file provided. At most one may be provided.")
     if content_file:
         try:
             with open(content_file) as f:
                 content = f.read()
         except FileNotFoundError:
-            raise FileNotFoundError(f'Content file {repr(content_file)} not found.')
+            raise FileNotFoundError(f"Content file {repr(content_file)} not found.")
     entry = create_collection_entry(content=content, collection=_collection, **parsed_args)
     if title:
         # If we had a title earlier this is where we replace the default that is added by the template handler with

--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -306,6 +306,12 @@ def new_entry(
         Optional[str],
         typer.Option(),
     ] = None,
+    content_file: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Path to a file containing the desired content.",
+        ),
+    ] = None,
     args: Annotated[
         Optional[list[str]],
         typer.Option(
@@ -318,6 +324,11 @@ def new_entry(
     parsed_args = split_args(args) if args else {}
     site = get_site(module, site_name)
     _collection = next(coll for coll in site.route_list.values() if type(coll).__name__.lower() == collection.lower())
+    if content and content_file:
+        raise TypeError('Both content and content_file provided. At most one may be provided.')
+    if content_file:
+        with open(content_file) as f:
+            content = f.read()
     entry = create_collection_entry(content=content, collection=_collection, **parsed_args)
     filepath = Path(_collection.content_path).joinpath(filename)
     filepath.write_text(entry)

--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -347,8 +347,11 @@ def new_entry(
     if content and content_file:
         raise TypeError('Both content and content_file provided. At most one may be provided.')
     if content_file:
-        with open(content_file) as f:
-            content = f.read()
+        try:
+            with open(content_file) as f:
+                content = f.read()
+        except FileNotFoundError:
+            raise FileNotFoundError(f'Content file {repr(content_file)} not found.')
     entry = create_collection_entry(content=content, collection=_collection, **parsed_args)
     if title:
         # If we had a title earlier this is where we replace the default that is added by the template handler with


### PR DESCRIPTION
Add `content-file` argument for `new-entry` so that users can pass a file without having to do `--content $(cat myfile)` 

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [X] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [X] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps


