### PR TITLE
Use config for default `module:site` and `collection`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
   "pytest-mock",
   "rich",
   "ruff",
+  "toml",
   "typer",
   "watchfiles",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cli = ["cookiecutter", "rich", "typer", "watchfiles"]
+cli = ["cookiecutter", "rich", "typer", "watchfiles", "toml"]
 extras = ["render-engine-sitemap"]
 dev = [
   "cookiecutter",

--- a/requirements.txt
+++ b/requirements.txt
@@ -218,6 +218,7 @@ sniffio==1.3.1
     # via anyio
 text-unidecode==1.3
     # via python-slugify
+toml==0.10.2
 typer==0.15.2
     # via render_engine (pyproject.toml)
 types-python-dateutil==2.9.0.20241206

--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -27,9 +27,9 @@ CONFIG_FILE_NAME = ".render-engine-config.json"
 try:
     with open(CONFIG_FILE_NAME) as stored_config_file:
         stored_config = json.load(stored_config_file)
-    print(f"Config loaded from {CONFIG_FILE_NAME}")
+    typer.echo(f"Config loaded from {CONFIG_FILE_NAME}")
 except FileNotFoundError:
-    print(f"No config file found at {CONFIG_FILE_NAME}")
+    typer.echo(f"No config file found at {CONFIG_FILE_NAME}")
     stored_config = {}
 
 # Initialize the arguments and default values

--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -1,6 +1,5 @@
 # ruff: noqa: UP007
 import importlib
-import json
 import os
 import re
 import shutil
@@ -26,17 +25,17 @@ CONFIG_FILE_NAME = "pyproject.toml"
 module_site_arg, collection_arg = None, None
 default_module_site, default_collection = None, None
 
+
 def load_config(config_file: str = CONFIG_FILE_NAME):
     """Load the config from the file"""
     global module_site_arg, collection_arg, default_module_site, default_collection
     try:
         with open(config_file) as stored_config_file:
-            stored_config = toml.load(stored_config_file).get('render-engine', {}).get('cli', {})
+            stored_config = toml.load(stored_config_file).get("render-engine", {}).get("cli", {})
         typer.echo(f"Config loaded from {config_file}")
     except FileNotFoundError:
         typer.echo(f"No config file found at {config_file}")
         stored_config = {}
-
 
     if stored_config:
         # Populate the argument variables and default values from the config
@@ -48,13 +47,14 @@ def load_config(config_file: str = CONFIG_FILE_NAME):
         if default_collection := stored_config.get("collection"):
             collection_arg = typer.Option(
                 help="The Collection from which your metadata is defined",
-                )
+            )
 
     # If there is no config, use the positional arguments.
     if not module_site_arg:
         module_site_arg = typer.Argument(help="module:site for Build the site prior to serving [REQUIRED]")
     if not collection_arg:
         collection_arg = typer.Argument(help="The Collection from which your metadata is defined [REQUIRED]")
+
 
 load_config()
 


### PR DESCRIPTION
Add support for a config file with defaults for:
- `module_site`
- `collection`

Issue #889 

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [X] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [X] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps

- Explore what else might be in the config file.
- Explore adding creating the config file via `cookiecutter`
