### PR TITLE
[TEST]:Rename Scorecard to fix security check issue

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -61,7 +61,7 @@ jobs:
       - name: "Upload artifact"
         uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
         with:
-          name: SARIF file
+          name: SARIF-file
           path: results.sarif
           retention-days: 5
 


### PR DESCRIPTION
According to Claude you can't have spaces in the SARIF name. This is a test to see if the renaming of the SARIF file fixes the security checks.
