### PR TITLE
Exclude dependabot changes from changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot


### PR DESCRIPTION
Configure GitHub's [automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) to exclude dependabot changes. This change intends to highlight feature and bugfixes rather than automated dependency upgrades in future changelog entries.

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [x] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [x] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

#### Changes have been Tested

- [ ] YES - Changes have been tested

#### Next Steps
