### PR TITLE
issue-898 - Date validation for new-entry

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ poetry.lock
 
 docs/site
 .vscode
+
+# So we can have a site that won't get nuked or committed by accident
+untitled-site/

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -186,7 +186,7 @@ render-engine new-entry [MODULE:SITE] [COLLECTION] [FILENAME] [OPTIONS]
 - `--title`: Entry title
 - `--slug`: URL slug for the entry
 - `--args`: Additional metadata as key=value or key:value pairs
-- `--include-date`: Add today's date to the entry. NOTE: If this is set and a 
+- `--include-date`: Add today's date to the entry. NOTE: If this is set and a
 date is included in the `--args` the one from the `--args` will be used.
 
 **Examples:**

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -186,6 +186,8 @@ render-engine new-entry [MODULE:SITE] [COLLECTION] [FILENAME] [OPTIONS]
 - `--title`: Entry title
 - `--slug`: URL slug for the entry
 - `--args`: Additional metadata as key=value or key:value pairs
+- `--include-date`: Add today's date to the entry. NOTE: If this is set and a 
+date is included in the `--args` the one from the `--args` will be used.
 
 **Examples:**
 
@@ -208,6 +210,10 @@ render-engine new-entry my_site:MySite blog review.md \
 render-engine new-entry my_site:MySite pages about.md \
     --title "About Us" \
     --slug "about-us"
+    
+# With --include-date
+render-engine new-entry my_site:MySite pages about.md \
+    --include-date
 ```
 
 **Notes:**

--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -16,6 +16,7 @@ from rich.table import Table
 
 from render_engine import Collection, Site
 from render_engine.cli.event import ServerEventHandler
+from toml import TomlDecodeError
 
 # Load the config file. The config the pyproject.toml. CLI config is in `render-engine.cli`
 
@@ -29,13 +30,17 @@ default_module_site, default_collection = None, None
 def load_config(config_file: str = CONFIG_FILE_NAME):
     """Load the config from the file"""
     global module_site_arg, collection_arg, default_module_site, default_collection
+    stored_config = {}
     try:
         with open(config_file) as stored_config_file:
-            stored_config = toml.load(stored_config_file).get("render-engine", {}).get("cli", {})
-        typer.echo(f"Config loaded from {config_file}")
+            try:
+                stored_config = toml.load(stored_config_file).get("render-engine", {}).get("cli", {})
+            except TomlDecodeError as exc:
+                typer.echo(f'Encountered an error while parsing {config_file} - {exc}.')
+            else:
+                typer.echo(f"Config loaded from {config_file}")
     except FileNotFoundError:
         typer.echo(f"No config file found at {config_file}")
-        stored_config = {}
 
     if stored_config:
         # Populate the argument variables and default values from the config

--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -1,4 +1,5 @@
 # ruff: noqa: UP007
+import datetime
 import importlib
 import os
 import re
@@ -10,13 +11,15 @@ from typing import Annotated, Optional
 
 import toml
 import typer
+from dateutil import parser as dateparser
+from dateutil.parser import ParserError
 from rich import print as rprint
 from rich.console import Console
 from rich.table import Table
+from toml import TomlDecodeError
 
 from render_engine import Collection, Site
 from render_engine.cli.event import ServerEventHandler
-from toml import TomlDecodeError
 
 # Load the config file. The config the pyproject.toml. CLI config is in `render-engine.cli`
 
@@ -36,7 +39,7 @@ def load_config(config_file: str = CONFIG_FILE_NAME):
             try:
                 stored_config = toml.load(stored_config_file).get("render-engine", {}).get("cli", {})
             except TomlDecodeError as exc:
-                typer.echo(f'Encountered an error while parsing {config_file} - {exc}.')
+                typer.echo(f"Encountered an error while parsing {config_file} - {exc}.")
             else:
                 typer.echo(f"Config loaded from {config_file}")
     except FileNotFoundError:
@@ -398,6 +401,13 @@ def new_entry(
             help="key value attrs to include in your entry use the format `--args key=value` or `--args key:value`",
         ),
     ] = None,
+    include_date: Annotated[
+        Optional[bool],
+        typer.Option(
+            help="Include today's date in your entry.",
+            is_flag=True,
+        ),
+    ] = False,
 ):
     """Creates a new collection entry based on the parser. Entries are added to the Collections content_path"""
     if not module_site or not collection or not filename:
@@ -415,6 +425,17 @@ def new_entry(
         # If `slug` is provided as a keyword add it to the `parsed_args` to be included in the rendering.
         # Prefer the keyword to what is passed via `--args`
         parsed_args["slug"] = slug
+    # Verify that we have a valid date should it be supplied or requested
+    if date := parsed_args.pop("date", None):
+        try:
+            date = dateparser.parse(date).isoformat()
+        except ParserError:
+            raise ValueError(f"Invalid date: {repr(date)}.") from None
+    elif include_date:
+        date = datetime.datetime.today().isoformat()
+    if date:
+        parsed_args["date"] = date
+
     site = get_site(module, site_name)
     _collection = next(coll for coll in site.route_list.values() if type(coll).__name__.lower() == collection.lower())
     if content and content_file:

--- a/tests/tests_cli/test_cli.py
+++ b/tests/tests_cli/test_cli.py
@@ -124,6 +124,19 @@ def test_config_loading_missing_file(tmp_path, monkeypatch, capsys):
     assert "No config file found" in captured.out
 
 
+def test_config_loading_invalid_file(tmp_path, monkeypatch, capsys):
+    """Tests config loading behavior when pyproject.toml is malformed"""
+
+    config_file = tmp_path / "pyproject.toml"
+    config_file.write_text("Lorem ipsum")
+
+    # Change to temp directory for config loading test
+    monkeypatch.chdir(tmp_path)
+
+    # Test that load_config doesn't raise an exception
+    load_config(str(config_file))
+
+
 def test_collection_entry_with_custom_attributes():
     """Tests that custom attributes are passed through to collection entry"""
     test_collection = Collection()


### PR DESCRIPTION
zAddresses issue #898 

- Add `include-date` option to `new-entry` to use the current date.
- Add validation for a date passed in via `--args`
- Always use `isoformat` for the date in the output of `new-entry`
- Add exception handling around parsing the config file.
- Fix hanging tests.

#### Type of Issue

- [X] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [X] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [X] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps

Build is still failing on trying to sort by the date from an entry.  This is seen by the following errors when trying to build/serve the site:

```
AttributeError: 'Page' object has no attribute 'date'

AttributeError: Cannot sort pages: 'date' attribute is missing from one or more pages.Make sure all pages in collection 'Blog' have the 'date' attribute
defined.
```
This is, I think, distinct from the issue #899.
Command run to create the entry:

```
 render-engine new-entry test.md --include-date --args "date: May 23, 2025" --content "Some content goes here" --slug test --title title --args "Author: ME"
 ```