### PR TITLE
possibly fix #845

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,17 @@ updates:
     # Check the pypi registry for updates every day (weekdays)
     schedule:
       interval: "monthly"
+    # Group dependencies by type production, development, and render-engine
+    # This will create a single PR for each group
+    groups:
+      # [project.dependencies] and [project.optional-dependencies].cli, needs to be confirmed
+      production:
+        dependency-type: "production"
+      development:
+        dependency-type: "development"
+      render-engine:
+        patterns:
+          - "render-engine-*"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,6 @@ updates:
   - package-ecosystem: "pip"
     # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
-    ignore:
-      - dependency-name: "Markdown"
-      # For Markdown, ignore all updates for version 3.4.X
-        versions: ["3.4.x"]
     # Check the pypi registry for updates every day (weekdays)
     schedule:
       interval: "monthly"

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,5 @@ tools
 
 # So we can have a site that won't get nuked or committed by accident
 untitled-site/
+
+.DS_Store


### PR DESCRIPTION
This change groups the dependencies into 3 groups production, developement, render-engien. We need to confirm that it works before closing the issue.

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [x] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [-] YES - Changes have been documented

#### Changes have been Tested

- [-] YES - Changes have been tested

#### Next Steps

Confirm this actually works according to the docs it should work but I couldn't find any online examples for it.
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#dependency-type-allow
