### PR TITLE
to_pub_date accepts date as well

### DIFF
--- a/src/render_engine/engine.py
+++ b/src/render_engine/engine.py
@@ -2,6 +2,7 @@ import datetime
 from email.utils import format_datetime as fmt_datetime
 from urllib.parse import urljoin
 
+from dateutil.parser import parse
 from jinja2 import (
     ChoiceLoader,
     Environment,
@@ -35,10 +36,13 @@ engine = Environment(
 )
 
 
-def to_pub_date(value: datetime.datetime):
+def to_pub_date(value: datetime.datetime | datetime.date):
     """
     Parse information from the given class object.
     """
+
+    if isinstance(value, datetime.date):
+        value = parse(value.isoformat())
     return fmt_datetime(value)
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3,7 +3,7 @@ import datetime
 import jinja2
 import pytest
 
-from render_engine.engine import format_datetime
+from render_engine.engine import format_datetime, to_pub_date
 
 
 @pytest.mark.parametrize(
@@ -34,3 +34,18 @@ def test_format_datetime(format, override, expected):
         value=datetime.datetime(2023, 9, 27, 14, 0, 0),
         datetime_format=override,
     )
+
+
+@pytest.mark.parametrize(
+    "pubdate",
+    (
+        (datetime.date(2025, 1, 1)),  # Test given value in jinja global
+        (datetime.datetime(2025, 1, 1)),  # Test given value in jinja global
+    ),
+)
+def test_to_pubdate(pubdate):
+    """
+    Tests that the datetime filter works with the following format:
+
+    """
+    assert to_pub_date(pubdate) == "Wed, 01 Jan 2025 00:00:00 -0000"


### PR DESCRIPTION
### Summary of Changes

The changes made in this PR improve the `to_pub_date` function in the render engine to handle both `datetime` and `date` objects more flexibly:

**Added Date Handling**: Added logic to convert `datetime.date` objects to `datetime.datetime` using the `dateutil.parser.parse` method before formatting, ensuring consistent handling of both types.

**Updated Tests**: Added new test cases in `test_engine.py` to verify that `to_pub_date` correctly handles both datetime and date inputs, ensuring backward compatibility while extending functionality.
