### PR TITLE
Handle pre- and post-collection build plugins.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,7 +153,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 poetry.lock
 
 docs/site

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -118,6 +118,21 @@ def test_collection_archive_runs_render_content_calls(site, mocker):
     assert mocker_post_render_content.called
 
 
+def test_collection_runs_render_pre_and_post_build_plugins(site, mocker):
+    mocker_render_content = mocker.patch.object(
+        site.route_list["fakecollection"].plugin_manager._pm.hook,
+        "pre_build_collection",
+    )
+    mocker_post_render_content = mocker.patch.object(
+        site.route_list["fakecollection"].plugin_manager._pm.hook,
+        "post_build_collection",
+    )
+
+    site.render()
+    assert mocker_render_content.called
+    assert mocker_post_render_content.called
+
+
 def test_page_plugins_registered():
     app = Site()
 


### PR DESCRIPTION
The `pre_build_collection` and `post_build_collection` plugins were not actually being called. 

#### Type of Issue

- [x] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps
