### PR TITLE
Fix issue with plugin settings not being properly passed into plugin hooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
+<!-- markdownlint-disable -->
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-18-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
+<!-- markdownlint-restore -->
 
 # Render Engine
 

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -99,8 +99,8 @@ points in the render engine lifecycle.
 
 Currently supported hooks are:
 
-| hook | parameters |
-| ____ | __________ |
+| Hook | Parameters |
+| ---- | ---- |
 | pre_build_site | `site: Site, settings: dict` |
 | post_build_site | `site: Site, settings: dict` |
 | pre_build_collection | `collection: Collection, site: Site, settings: dict` |

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -1,4 +1,4 @@
-from src.render_engine.plugins import hook_impl---
+---
 title: "Enhancing Functionality with Plugins"
 description: "Guide to using and managing plugins in Render Engine. Learn how to register plugins, apply them to pages and collections, and exclude specific plugins."
 date: August 22, 2024

--- a/src/render_engine/collection.py
+++ b/src/render_engine/collection.py
@@ -248,21 +248,21 @@ class Collection(BaseObject):
         for page in self.pages:  # noqa: UP028
             yield page
 
-    def _run_collection_plugins(self, settings: dict, site, hook_type: str):
+    def _run_collection_plugins(self, site, hook_type: str):
         """
         Run plugins for a collection
 
-        :param settings: Dictionary of plugin settings
+        :param site: The site object triggering the call
         :param hook_type: The hook to run
         """
         if not getattr(self.plugin_manager, "_pm", None) or not self.plugin_manager.plugins:
             return
         try:
-            method = getattr(self.plugin_manager._pm.hook, hook_type)
+            method = getattr(self.plugin_manager.hook, hook_type)
         except AttributeError:
             logging.error(f"Unknown {hook_type=}")
             return
-        method(collection=self, site=site, settings=settings)
+        method(collection=self, site=site, settings=self.plugin_manager.plugin_settings)
 
 
 def render_archives(archive, **kwargs) -> list[Archive]:

--- a/src/render_engine/plugins.py
+++ b/src/render_engine/plugins.py
@@ -42,6 +42,7 @@ class SiteSpecs:
     def post_build_site(
         self,
         site,
+        settings: dict[str, Any],
     ) -> None:
         """Build After Building the site"""
 
@@ -50,6 +51,7 @@ class SiteSpecs:
         self,
         page,
         settings: dict[str, Any],
+        site,
     ) -> None:
         """
         Augments the content of the page before it is rendered as output.
@@ -115,3 +117,13 @@ class PluginManager:
             set: A set containing the registered plugins.
         """
         return self._pm.get_plugins()
+
+    @property
+    def hook(self):
+        """
+        Give access to the hook to run plugins.
+
+        Returns:
+            HookRelay: The hook to actually trigger the plugins.
+        """
+        return self._pm.hook

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -298,7 +298,10 @@ class Site:
 
         with Progress() as progress:
             pre_build_task = progress.add_task("Loading Pre-Build Plugins", total=1)
-            self.plugin_manager._pm.hook.pre_build_site(site=self, settings=self.site_settings.get("plugins", {}))  # type: ignore
+            self.plugin_manager.hook.pre_build_site(
+                site=self,
+                settings=self.plugin_manager.plugin_settings,
+            )  # type: ignore
 
             self.load_themes()
             self.theme_manager.engine.globals.update(self.site_vars)
@@ -327,7 +330,6 @@ class Site:
                     )
                     pre_build_collection_task = progress.add_task("Loading Pre-Build-Collection Plugins", total=1)
                     entry._run_collection_plugins(
-                        settings=self.site_settings.get("plugins", {}),
                         hook_type="pre_build_collection",
                         site=self,
                     )
@@ -343,7 +345,6 @@ class Site:
                         total=len(entry.plugin_manager.plugins),
                     )
                     entry._run_collection_plugins(
-                        settings=self.site_settings.get("plugins", {}),
                         hook_type="post_build_collection",
                         site=self,
                     )
@@ -351,7 +352,8 @@ class Site:
                 progress.update(task_add_route, advance=1)
 
             progress.add_task("Loading Post-Build Plugins", total=1)
-            self.plugin_manager._pm.hook.post_build_site(
+            self.plugin_manager.hook.post_build_site(
                 site=self,
+                settings=self.plugin_manager.plugin_settings,
             )
             progress.update(pre_build_task, advance=1)


### PR DESCRIPTION
Issue #923

- Fix issue where plugin settings were not being properly transmitted to the hooks.
- Fix issue with plugin hooks missing parameters
- Add `hook` property to `PluginManager` 
- Improve plugin documentation.

#### Type of Issue

- [X] :bug: (bug)
- [X] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [X] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps

<!--ANY FURTHER STEPS TO BE TAKEN-->
