### PR TITLE
Implement uniform handling of plugin registration

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -7,6 +7,8 @@ tags: ["plugins", "render-engine", "customization"]
 
 Plugins are a way to extend the functionality of the render engine site.
 
+## Registering Plugins
+
 Plugins are registered by using `register_plugins`
 
 ```python
@@ -34,6 +36,29 @@ class MyCollection(Collection):
 
 my_site.route_list['mypage']._pm.list_name_plugin()
 >>> ['MyPlugin']
+```
+
+When the `site.collection` and `site.page` methods are called the collection/page is populated with all currently
+registered plugins. Additional calls to `site.register_plugins` after the call to `site.collection` or
+`site.page` will **not** register the new plugin with the collection/page.
+
+```python
+from render_engine import Site, Collection, Page
+from my_plugins import Plugin1, Plugin2
+
+app = Site()
+app.register_plugins(Plugin1)
+
+
+@my_site.page # Plugin1 is registered here.
+class MyPage(Page):
+    pass
+
+@site.collection # Plugin1 is registered here.
+class MyCollection(Collection):
+    pass
+
+app.register_plugins(Plugin2) # Plugin2 is only registered for the site and not for MyPage or MyCollection
 ```
 
 ## Single Page/Collection plugins

--- a/src/render_engine/page.py
+++ b/src/render_engine/page.py
@@ -5,6 +5,7 @@ from jinja2 import Environment, Template
 from render_engine_parser.base_parsers import BasePageParser
 
 from ._base_object import BaseObject
+from .plugins import PluginManager
 
 
 class BasePage(BaseObject):
@@ -31,6 +32,7 @@ class BasePage(BaseObject):
     template: str | Template | None
     rendered_content: str | None
     _reference: str = "_slug"
+    plugin_manager: PluginManager | None
 
     @property
     def _content(self) -> any:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -106,7 +106,7 @@ def test_pages_in_collection_inherit_pugins(site: Site):
 def test_page_ignores_plugin(site: Site):
     """Check that the plugin is not registered in the page if it is ignored"""
 
-    assert site.route_list["testpage"]._pm.list_name_plugin() == []
+    assert site.route_list["testpage"].plugin_manager._pm.list_name_plugin() == []
 
 
 def test_collection_ignores_plugin(site):
@@ -158,7 +158,7 @@ def test_page_plugins_registered():
     class TestPage(Page):
         plugins = [FakePlugin]
 
-    assert app.route_list["testpage"]._pm.list_name_plugin()[0][0] == "FakePlugin"
+    assert app.route_list["testpage"].plugin_manager._pm.list_name_plugin()[0][0] == "FakePlugin"
 
 
 def test_deperecated_warning():
@@ -308,7 +308,6 @@ def plugin_test_site(tmp_path):
 )
 def test_plugin_settings_are_passed_properly(plugin_test_site, settings, expected):
     """Test that plugins are properly passed"""
-    plugin_test_site.register_plugins(TestPlugin, TestPlugin=settings)
 
     class Page1(Page):
         content = "this is a page"
@@ -316,6 +315,9 @@ def test_plugin_settings_are_passed_properly(plugin_test_site, settings, expecte
     @plugin_test_site.collection
     class LegacyPluginCollection(Collection):
         pages = [Page1()]
+        plugins = [(TestPlugin, settings)] if settings else [TestPlugin]
+
+    plugin_test_site.register_plugins(TestPlugin, TestPlugin=settings)
 
     plugin_test_site.render()
     for hook in ["prebuild", "postbuild", "prebuildcollection", "postbuildcollection"]:


### PR DESCRIPTION
Resolves #937
Resolves #928

- Fix plugin registration issues to
  - Match the documentation
  - Allow passing of settings when adding plugins in the page/collection definition
- Minor modifications to `PluginManager` so that class don't need to access `_pm` directly. 
- Add documentation around order of operations for plugin registration

#### Type of Issue

- [x] :bug: (bug)
- [x] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [x] YES - Changes have been documented

#### Changes have been Tested

- [x] YES - Changes have been tested

#### Next Steps
