### PR TITLE
use datetime timeznoe utc and adds support to 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
       fail-fast: true
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ branch = "main"
 [tool.ruff]
 line-length = 120
 indent-width = 4
-target-version = "py312"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]

--- a/tests/test_feeds/test_feeds.py
+++ b/tests/test_feeds/test_feeds.py
@@ -1,4 +1,5 @@
 import datetime
+from datetime import timezone
 
 import pluggy
 import pytest
@@ -78,7 +79,7 @@ def test_rss_feed_template_with_strictundefined(engine, tmp_path):
 @pytest.mark.parametrize(
     "date",
     [
-        datetime.datetime(2023, 4, 15, 0, 0, 0, tzinfo=datetime.UTC),
+        datetime.datetime(2023, 4, 15, 0, 0, 0, tzinfo=timezone.utc),
         datetime.datetime(2023, 4, 15, 0, 0, 0, tzinfo=None),
         datetime.date(2024, 4, 15),
     ],
@@ -87,7 +88,7 @@ def test_rss_feed_template_parses_date_correctly(engine, date):
     """Tests that a feed parses the page date in RFC2822 Format"""
 
     class TestPage(Page):
-        date = datetime.datetime(2023, 4, 15, 0, 0, 0, tzinfo=datetime.UTC)  # noqa: UP017
+        date = datetime.datetime(2023, 4, 15, 0, 0, 0, tzinfo=timezone.utc)  # noqa: UP017
 
     class TestCollection(Collection):
         Feed = RSSFeed


### PR DESCRIPTION
- **fix datetime to make testing compatible with 3.10**
- **add 3.10 to ci/cd tests**

I'm combining the PRs so that 3.10 support fixed.

the fix was to change from  `datetime.UTC` to `datetime.timezone.utc`
