### PR TITLE
Fix plugin for pages in a collection. Fix progress for collection plugins. Run `ruff` and fix some issues there too.

### DIFF
--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -225,9 +225,9 @@ class Site:
         """Iterate through Pages and Check for Collections and Feeds"""
 
         for entry in collection:
-            entry._pm = copy.deepcopy(self.plugin_manager._pm)
+            entry.plugin_manager = copy.deepcopy(self.plugin_manager)
 
-            for route in collection.routes:
+            for route in entry.routes:
                 self._render_output(route, entry)
 
         if getattr(collection, "has_archive", False):
@@ -316,7 +316,10 @@ class Site:
                         task_add_route,
                         description=f"[blue]Adding[gold]Route: [blue]Collection {entry._slug}",
                     )
-                    pre_build_collection_task = progress.add_task("Loading Pre-Build-Collection Plugins", total=1)
+                    pre_build_collection_task = progress.add_task(
+                        "Loading Pre-Build-Collection Plugins",
+                        total=1,
+                    )
                     entry._run_collection_plugins(
                         hook_type="pre_build_collection",
                         site=self,
@@ -327,7 +330,7 @@ class Site:
 
                     post_build_collection_task = progress.add_task(
                         "Loading Post-Build-Collection Plugins",
-                        total=len(entry.plugin_manager.plugins),
+                        total=1,
                     )
                     entry._run_collection_plugins(
                         hook_type="post_build_collection",

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -266,6 +266,26 @@ class TestPlugin:
 
     @staticmethod
     @hook_impl
+    def render_content(site: Site, settings: dict):
+        class RenderContent(Page):
+            content = json.dumps(settings.get("TestPlugin"))
+            name = "renddercontent"
+
+        print("RenderContent")
+        site._render_output(site.output_path, RenderContent())
+
+    @staticmethod
+    @hook_impl
+    def post_render_content(site: Site, settings: dict):
+        class PostRenderContent(Page):
+            content = json.dumps(settings.get("TestPlugin"))
+            name = "postrendercontent"
+
+        print("PostRenderContent")
+        site._render_output(site.output_path, PostRenderContent())
+
+    @staticmethod
+    @hook_impl
     def pre_build_collection(site: Site, settings: dict):
         class PreBuildCollection(Page):
             content = json.dumps(settings.get("TestPlugin"))
@@ -320,7 +340,14 @@ def test_plugin_settings_are_passed_properly(plugin_test_site, settings, expecte
     plugin_test_site.register_plugins(TestPlugin, TestPlugin=settings)
 
     plugin_test_site.render()
-    for hook in ["prebuild", "postbuild", "prebuildcollection", "postbuildcollection"]:
+    for hook in [
+        "prebuild",
+        "postbuild",
+        "prebuildcollection",
+        "postbuildcollection",
+        "rendercontent",
+        "postrendercontent",
+    ]:
         path = plugin_test_site.output_path / f"{hook}.html"
         with open(path) as f:
             assert json.load(f) == expected, f"Failed to match {settings=} to {expected=}"


### PR DESCRIPTION
- Fix iss where `plugin_manager` was not assigned to pages in a `Collection`
- Fix issue where we were using the collection's routes instead of the page's when rendering pages in a collection
- Fix issue with progress bar for collection plugins (should have been 1 not `len(plugins)` since we can't track the plugins actually running.)

#### Type of Issue

- [X] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps

