### PR TITLE
Fix issues with `serve --reload`

### DIFF
--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -68,14 +68,15 @@ load_config()
 app = typer.Typer()
 
 
-def get_site_content_paths(site: Site) -> list[Path | None]:
+def get_site_content_paths(site: Site) -> list[Path | str | None]:
     """Get the content paths from the route_list in the Site"""
 
     base_paths = map(lambda x: getattr(x, "content_path", None), site.route_list.values())
-    base_paths = list(filter(lambda x: x is not None, base_paths))
+    base_paths = list(filter(None, base_paths))
     base_paths.extend(site.static_paths)
-    base_paths.append(site.template_path)
-    return base_paths
+    if site.template_path:
+        base_paths.append(site.template_path)
+    return list(filter(None, base_paths))
 
 
 def remove_output_folder(output_path: Path) -> None:

--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -1,11 +1,9 @@
 # ruff: noqa: UP007
 import datetime
-import importlib
 import os
 import re
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 from typing import Annotated, Optional
 
@@ -20,6 +18,7 @@ from toml import TomlDecodeError
 
 from render_engine import Collection, Site
 from render_engine.cli.event import ServerEventHandler
+from render_engine.cli.utils import get_site
 
 # Load the config file. The config the pyproject.toml. CLI config is in `render-engine.cli`
 
@@ -74,13 +73,6 @@ def get_site_content_paths(site: Site) -> list[Path | None]:
 
     base_paths = map(lambda x: getattr(x, "content_path", None), site.route_list.values())
     return list(filter(lambda x: x is not None, base_paths))
-
-
-def get_site(import_path: str, site: str) -> Site:
-    """Split the site module into a module and a class name"""
-    sys.path.insert(0, ".")
-    importlib.import_module(import_path)
-    return getattr(sys.modules[import_path], site)
 
 
 def remove_output_folder(output_path: Path) -> None:
@@ -343,7 +335,8 @@ def serve(
         import_path=module,
         server_address=server_address,
         dirs_to_watch=get_site_content_paths(site) if reload else None,
-        site=site,
+        site=site_name,
+        output_path=site.output_path,
         patterns=None,
         ignore_patterns=[r".*output\\*.+$", r"\.\\\..+$", r".*__.*$"],
     )

--- a/src/render_engine/cli/cli.py
+++ b/src/render_engine/cli/cli.py
@@ -72,7 +72,10 @@ def get_site_content_paths(site: Site) -> list[Path | None]:
     """Get the content paths from the route_list in the Site"""
 
     base_paths = map(lambda x: getattr(x, "content_path", None), site.route_list.values())
-    return list(filter(lambda x: x is not None, base_paths))
+    base_paths = list(filter(lambda x: x is not None, base_paths))
+    base_paths.extend(site.static_paths)
+    base_paths.append(site.template_path)
+    return base_paths
 
 
 def remove_output_folder(output_path: Path) -> None:

--- a/src/render_engine/cli/event.py
+++ b/src/render_engine/cli/event.py
@@ -87,7 +87,6 @@ class ServerEventHandler:
 
     def rebuild(self) -> None:
         console.print("[bold purple]Reloading and Rebuilding site...[/bold purple]")
-        console.print("[bold green]Rebuilding site[/bold green]")
         site = get_site(self.import_path, self.site, reload=True)
         try:
             site.render()

--- a/src/render_engine/cli/event.py
+++ b/src/render_engine/cli/event.py
@@ -1,12 +1,12 @@
-import importlib
 import threading
 import time
+import traceback
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 
 import watchfiles
 from rich.console import Console
 
-from render_engine import Site
+from render_engine.cli.utils import get_site
 
 console = Console()
 
@@ -54,7 +54,8 @@ class ServerEventHandler:
         self,
         server_address: tuple[str, int],
         import_path: str,
-        site: Site,
+        site: str,
+        output_path: str,
         dirs_to_watch: str | None = None,
         patterns: list[str] | None = None,
         ignore_patterns: list[str] | None = None,
@@ -65,6 +66,7 @@ class ServerEventHandler:
         self.server_address = server_address
         self.import_path = import_path
         self.site = site
+        self.output_path = output_path
         self.dirs_to_watch = dirs_to_watch
         self.patterns = patterns
         self.ignore_patterns = ignore_patterns
@@ -74,7 +76,7 @@ class ServerEventHandler:
             console.print(
                 f"[bold green]Spawning server on http://{self.server_address[0]}:{self.server_address[1]}[/bold green]"
             )
-            self.server = spawn_server(self.server_address, self.site.output_path)
+            self.server = spawn_server(self.server_address, self.output_path)
         self._thread = threading.Thread(target=self.server.serve_forever)
         self._thread.start()
 
@@ -85,9 +87,14 @@ class ServerEventHandler:
 
     def rebuild(self) -> None:
         console.print("[bold purple]Reloading and Rebuilding site...[/bold purple]")
-        module = importlib.import_module(self.import_path)
-        importlib.reload(module)
-        self.site.render()
+        console.print("[bold green]Rebuilding site[/bold green]")
+        site = get_site(self.import_path, self.site, reload=True)
+        try:
+            site.render()
+        except Exception:
+            console.print("[bold red]Failed to render site[/bold red]")
+            console.print(traceback.format_exc())
+            pass
 
     def stop_watcher(self) -> bool:
         """
@@ -116,7 +123,7 @@ class ServerEventHandler:
         If a KeyboardInterrupt is raised, it stops the observer and server.
         """
 
-        console.print(f"[yellow]Serving {self.site.output_path}[/yellow]")
+        console.print(f"[yellow]Serving {self.output_path}[/yellow]")
         while not self.stop_watcher():
             if self.dirs_to_watch:
                 for _ in watchfiles.watch(*self.dirs_to_watch):

--- a/src/render_engine/cli/utils.py
+++ b/src/render_engine/cli/utils.py
@@ -1,0 +1,13 @@
+import importlib
+import sys
+
+from render_engine import Site
+
+
+def get_site(import_path: str, site: str, reload: bool = False) -> Site:
+    """Split the site module into a module and a class name"""
+    sys.path.insert(0, ".")
+    imported = importlib.import_module(import_path)
+    if reload:
+        importlib.reload(imported)
+    return getattr(imported, site)

--- a/tests/tests_cli/test_cli.py
+++ b/tests/tests_cli/test_cli.py
@@ -45,7 +45,10 @@ def test_get_site_content_path(site, tmp_path_factory):
     content_path1 = tmp_path_factory.getbasetemp() / "test_content_path1.txt"
     content_path2 = tmp_path_factory.getbasetemp() / "test_content_path2.txt"
 
-    assert get_site_content_paths(site) == [content_path1, content_path2]
+    expected = [content_path1, content_path2]
+    expected.extend(site.static_paths)
+    expected.append(site.template_path)
+    assert get_site_content_paths(site) == expected
 
 
 @pytest.mark.skip("Not sure how to test importlib")

--- a/tests/tests_cli/test_render_engine_cli.py
+++ b/tests/tests_cli/test_render_engine_cli.py
@@ -38,7 +38,8 @@ def event_handler(site):
     handler = Handler(
         server_address=(hostname, free_port),
         import_path="tests.tests_cli.test_render_engine_cli",
-        site=site,
+        site='test_site',
+        output_path=site.output_path,
         dirs_to_watch=None,
     )
 

--- a/tests/tests_cli/test_render_engine_cli.py
+++ b/tests/tests_cli/test_render_engine_cli.py
@@ -38,7 +38,7 @@ def event_handler(site):
     handler = Handler(
         server_address=(hostname, free_port),
         import_path="tests.tests_cli.test_render_engine_cli",
-        site='test_site',
+        site="test_site",
         output_path=site.output_path,
         dirs_to_watch=None,
     )


### PR DESCRIPTION
Resolves issues #913 and #782

- Fix issues with `serve --reload` not actually re-rendering the site.
- Handle exceptions gracefully when they occur during a reload.
- Add `static` and `template` paths to watched for `serve --reload`.

#### Type of Issue

- [X] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps

It might not be a bad idea to have something that can catch user input as a way to exit the server cleanly. Possibly even force a `reload` so that changes to the python would also be handled.
