### PR TITLE
Fix broken links to Page, Site, and Collection in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 
 ## The _3 layer_ Architecture
 
-- **[Page](.github/render_engine/page.html)** - A single webpage item built from content, a template, raw data, or a combination of those things.
-- **[Collection](.github/render_engine/collection.html)** - A group of webpages built from the same template, organized in a single directory
-- **[Site](.github/render_engine/site.html)** - The container that helps to render all Pages and Collections with uniform settings and variables
+- **[Page](https://render-engine.readthedocs.io/en/latest/page/)** - A single webpage item built from content, a template, raw data, or a combination of those things.
+- **[Collection](https://render-engine.readthedocs.io/en/latest/collection/)** - A group of webpages built from the same template, organized in a single directory
+- **[Site](https://render-engine.readthedocs.io/en/latest/site/)** - The container that helps to render all Pages and Collections with uniform settings and variables
 
 ## Installing Render Engine
 


### PR DESCRIPTION
This PR fixes issue #952 by updating broken links in the README.md file:
- Page → https://render-engine.readthedocs.io/en/latest/page/
- Site → https://render-engine.readthedocs.io/en/latest/site/
- Collection → https://render-engine.readthedocs.io/en/latest/collection/

These previously led to 404 errors due to incorrect local paths.

