### PR TITLE
Add ability to use a `list` for collection sort.

### DIFF
--- a/docs/docs/collection.md
+++ b/docs/docs/collection.md
@@ -25,6 +25,8 @@ Collection pages **MUST** come from a `content_path` and all be the same content
 
 `content_path` can be a string representing a path or URL, depending on the [parser](parsers.md?id=basepageparser) used.
 
+`sort_by` can be either a single `attribute` as a `str` or a `list` of attributes to be used as a sort key.
+
 Attributes:
 
 ```Python
@@ -39,7 +41,7 @@ Parser: BasePageParser = BasePageParser
 parser_extras: dict[str, Any]
 required_themes: list[callable]
 routes: list[str] = ["./"]
-sort_by: str = "title"
+sort_by: str | list = "title"
 sort_reverse: bool = False
 title: str
 template: str | None

--- a/src/render_engine/collection.py
+++ b/src/render_engine/collection.py
@@ -51,7 +51,7 @@ class Collection(BaseObject):
         parser_extras: dict[str, Any]
         required_themes: list[callable]
         routes: list[str | Path] = ["./"]
-        sort_by: str = "title"
+        sort_by: str | list = "title"
         sort_reverse: bool = False
         title: str
         template: str | None

--- a/src/render_engine/collection.py
+++ b/src/render_engine/collection.py
@@ -79,7 +79,7 @@ class Collection(BaseObject):
     parser_extras: dict[str, Any]
     required_themes: list[Callable]
     routes: list[str | Path] = ["./"]
-    sort_by: str = "_title"
+    sort_by: str | list = "_title"
     sort_reverse: bool = False
     template_vars: dict[str, Any]
     template: str | None
@@ -140,6 +140,16 @@ class Collection(BaseObject):
         _date = dateparse.parse(date) if isinstance(date, str) else copy.copy(date)
         return _date.replace(tzinfo=None) if isinstance(_date, datetime.datetime) else _date
 
+    def _sort_key(self, key: str | list[str]) -> Callable:
+        """
+        Dynamically generate the sorting key
+
+        :param key: The key to use
+        """
+        if isinstance(key, str):
+            return self._date_key if key == "date" else lambda page: getattr(page, key)
+        return lambda page: [getattr(page, attr) for attr in key]
+
     @property
     def sorted_pages(self):
         """
@@ -150,12 +160,10 @@ class Collection(BaseObject):
             TypeError: This happens when the values being compared are of two different types
 
         """
-        # Dates need special handling so figure out if that's needed and set it here
-        sort_key = self._date_key if self.sort_by == "date" else lambda page: getattr(page, self.sort_by)
         try:
             return sorted(
                 (page for page in self.__iter__()),
-                key=sort_key,
+                key=self._sort_key(self.sort_by),
                 reverse=self.sort_reverse,
             )
         except AttributeError as e:

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -267,3 +267,96 @@ def test_collection_sort_by_error_missing():
     assert "Cannot sort pages" in str(excinfo.value)
     assert "custom_sort_content" in str(excinfo.value)
     assert "SortByErrorCollection" in str(excinfo.value)
+
+
+def test_collection_custom_sort_by_list():
+    """
+    Tests that the sort_by can be changed
+    """
+
+    class PageA(Page):
+        title = "Page A"
+        content = "This Page should list first"
+        custom_sort_content = "z"
+        other_sort_content = 1
+
+    class PageB(Page):
+        title = "Page B"
+        content = "This Page should list second"
+        custom_sort_content = "4"
+        other_sort_content = 1
+
+    class PageC(Page):
+        title = "Page C"
+        content = "This Page should list third"
+        custom_sort_content = "b"
+        other_sort_content = 1
+
+    # Create instances of the page classes
+    page_a = PageA()
+    page_b = PageB()
+    page_c = PageC()
+
+    # Expected order based on custom_sort_content: 4, b, z
+    expected_pages = [page_b, page_c, page_a]
+
+    # Create a mixed order of pages
+    mixed_pages = [page_a, page_c, page_b]
+
+    class CustomCollection(Collection):
+        sort_by = ["other_sort_content", "custom_sort_content"]
+        pages = mixed_pages
+
+    custom_collection = CustomCollection()
+    sorted_pages = list(custom_collection.sorted_pages)
+
+    # Verify the sorted order by checking custom_sort_content values
+    assert [page.custom_sort_content for page in sorted_pages] == [page.custom_sort_content for page in expected_pages]
+
+
+def test_collection_custom_sort_by_list_with_date():
+    """
+    Tests that the sort_by can be changed
+    """
+
+    class PageA(Page):
+        title = "Page A"
+        content = "This Page should list first"
+        custom_sort_content = "z"
+        other_sort_content = 1
+        date = "2025-06-01"
+
+    class PageB(Page):
+        title = "Page B"
+        content = "This Page should list second"
+        custom_sort_content = "4"
+        date = "2025-06-01"
+        other_sort_content = 1
+
+    class PageC(Page):
+        title = "Page C"
+        content = "This Page should list third"
+        custom_sort_content = "b"
+        other_sort_content = 1
+        date = "2025-06-02"
+
+    # Create instances of the page classes
+    page_a = PageA()
+    page_b = PageB()
+    page_c = PageC()
+
+    # Expected order based on custom_sort_content: 4, b, z
+    expected_pages = [page_b, page_a, page_c]
+
+    # Create a mixed order of pages
+    mixed_pages = [page_a, page_c, page_b]
+
+    class CustomCollection(Collection):
+        sort_by = ["other_sort_content", "date", "custom_sort_content"]
+        pages = mixed_pages
+
+    custom_collection = CustomCollection()
+    sorted_pages = list(custom_collection.sorted_pages)
+
+    # Verify the sorted order by checking custom_sort_content values
+    assert [page.custom_sort_content for page in sorted_pages] == [page.custom_sort_content for page in expected_pages]


### PR DESCRIPTION
Add more flexibility to sorting a collection by allowing a `list` for `sort_by`

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [X] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [X] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps

Do we want to add the ability to send a `Callable` as a sort key?