### PR TITLE
Fix documentation for CLI config in pyproject.toml

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -29,7 +29,7 @@ collection = "blog"  # optional
 ### Example Configuration
 
 ```toml
-[render-engine.cli]
+[tool.render-engine.cli]
 module = "my_site"
 site = "MySite"
 collection = "posts"


### PR DESCRIPTION
Resolves #965 by updating the documentation for how to configure the CLI via `pyproject.toml`

#### Type of Issue

- [ ] :bug: (bug)
- [x] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [x] YES - Changes have been documented

#### Changes have been Tested

- [ ] YES - Changes have been tested

#### Next Steps

