### PR TITLE
Have `Page` and `Collection` handle their own rendering.

### DIFF
--- a/src/render_engine/_base_object.py
+++ b/src/render_engine/_base_object.py
@@ -126,3 +126,7 @@ class BaseObject:
                 base_dict[key] = value
 
         return base_dict
+
+    def render(self, *args, **kwargs):
+        """Render method. Implemented in child objects"""
+        raise NotImplementedError(f'{self.__class__.__name__} does not implement the "render" method.')

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -252,7 +252,9 @@ class TestPlugin:
             name = "prebuild"
 
         print("PreBuild")
-        site._render_output(site.output_path, PreBuild())
+        prebuild = PreBuild()
+        prebuild.site = site
+        prebuild.render("./", site.theme_manager)
 
     @staticmethod
     @hook_impl
@@ -262,7 +264,9 @@ class TestPlugin:
             name = "postbuild"
 
         print("PostBuild")
-        site._render_output(site.output_path, PostBuild())
+        postbuild = PostBuild()
+        postbuild.site = site
+        postbuild.render("./", site.theme_manager)
 
     @staticmethod
     @hook_impl
@@ -272,7 +276,9 @@ class TestPlugin:
             name = "renddercontent"
 
         print("RenderContent")
-        site._render_output(site.output_path, RenderContent())
+        renddercontent = RenderContent()
+        renddercontent.site = site
+        renddercontent.render("./", site.theme_manager)
 
     @staticmethod
     @hook_impl
@@ -282,7 +288,9 @@ class TestPlugin:
             name = "postrendercontent"
 
         print("PostRenderContent")
-        site._render_output(site.output_path, PostRenderContent())
+        postrendercontent = PostRenderContent()
+        postrendercontent.site = site
+        postrendercontent.render("./", site.theme_manager)
 
     @staticmethod
     @hook_impl
@@ -290,9 +298,12 @@ class TestPlugin:
         class PreBuildCollection(Page):
             content = json.dumps(settings.get("TestPlugin"))
             name = "prebuildcollection"
+            site = site
 
         print("PreBuildCollection")
-        site._render_output(site.output_path, PreBuildCollection())
+        prebuildcollection = PreBuildCollection()
+        prebuildcollection.site = site
+        prebuildcollection.render("./", site.theme_manager)
 
     @staticmethod
     @hook_impl
@@ -302,7 +313,9 @@ class TestPlugin:
             name = "postbuildcollection"
 
         print("PostBuildCollection")
-        site._render_output(site.output_path, PostBuildCollection())
+        postbuildcollection = PostBuildCollection()
+        postbuildcollection.site = site
+        postbuildcollection.render("./", site.theme_manager)
 
 
 @pytest.fixture(scope="function")
@@ -313,9 +326,7 @@ def plugin_test_site(tmp_path):
     class TestSite(Site):
         output_path = _output_path
 
-    site = TestSite()
-
-    yield site
+    yield TestSite()
 
 
 @pytest.mark.parametrize(
@@ -331,6 +342,7 @@ def test_plugin_settings_are_passed_properly(plugin_test_site, settings, expecte
 
     class Page1(Page):
         content = "this is a page"
+        site = plugin_test_site
 
     @plugin_test_site.collection
     class LegacyPluginCollection(Collection):

--- a/tests/test_templates/test_base_html.py
+++ b/tests/test_templates/test_base_html.py
@@ -24,15 +24,16 @@ def theme_site(tmp_path):
 def test_base_html_body_class(theme_site):
     """body class is added to base html template"""
 
-    class bodyClassTheme(Theme):
+    class BodyClassTheme(Theme):
         template_globals = {"body_class": "my-class"}
         loader = DictLoader({})
         filters = {}
         plugins = []
         prefix = "test"
 
-    theme_site.register_themes(bodyClassTheme)
-    theme_site._render_output("./", theme_site.route_list["testpage"])
+    theme_site.register_themes(BodyClassTheme)
+    theme_site.route_list["testpage"].site = theme_site
+    theme_site.route_list["testpage"].render("./", theme_site.theme_manager)
 
     assert '<body class="my-class">' in (theme_site.output_path / "testpage.html").read_text()
 
@@ -40,16 +41,17 @@ def test_base_html_body_class(theme_site):
 def test_base_html_head_include(theme_site):
     """head can be imported into base html template"""
 
-    class headIncludeTheme(Theme):
+    class HeadIncludeTheme(Theme):
         template_globals = {"head": "head.html"}
         loader = DictLoader({"head.html": "<script>console.log('test')</script>"})
         filters = set()
         plugins = []
         prefix = "test"
 
-    theme_site.register_themes(headIncludeTheme)
+    theme_site.register_themes(HeadIncludeTheme)
     theme_site.load_themes()
-    theme_site._render_output("./", theme_site.route_list["testpage"])
+    theme_site.route_list["testpage"].site = theme_site
+    theme_site.route_list["testpage"].render("./", theme_site.theme_manager)
 
     assert "<script>console.log('test')</script>" in (theme_site.output_path / "testpage.html").read_text()
 


### PR DESCRIPTION
Resolves issue #967

- `Page` objects handle their own rendering
- `Collection` objects handle their own rendering
- Update tests for changes needed to have `Page` and `Collection` handle their own rendering

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [X] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented
NA

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps

