### PR TITLE
Finalize Site Map functionality

### DIFF
--- a/docs/docs/collection.md
+++ b/docs/docs/collection.md
@@ -46,6 +46,7 @@ sort_reverse: bool = False
 title: str
 template: str | None
 archive_template str | None: The template to use for the archive pages.
+skip_site_map: bool = False: Flag to indicate whether this Collection should not be included in the SiteMap.
 ```
 
 ## Attributes

--- a/docs/docs/page.md
+++ b/docs/docs/page.md
@@ -24,12 +24,13 @@ This is not intended to be used directly.
 
 **Attributes:**
 
-| Name | Type | Description |
-| --- | --- | --- |
-| `slug` |  |The slug of the page. Defaults to the `title` slugified. |
-| `content` |  |The content to be rendered by the page |
-| `parser` |  |The Parser used to parse the page's content. Defaults to `BasePageParser`. |
-| `reference` |  |The attribute to use as the reference for the page in the site's route list. Defaults to `slug`. |
+| Name               | Type | Description |
+|--------------------| --- | --- |
+| `slug`             |  |The slug of the page. Defaults to the `title` slugified. |
+| `content`          |  |The content to be rendered by the page |
+| `parser`           |  |The Parser used to parse the page's content. Defaults to `BasePageParser`. |
+| `reference`        |  |The attribute to use as the reference for the page in the site's route list. Defaults to `slug`. |
+| `skip_site_map`    | `False` | When set to `True` the `Page` will not be included in the generated `SiteMap` |
 
 ### Functions
 
@@ -72,6 +73,7 @@ When you create a page, you specify variables passed into rendering template.
 | `template` | `str | None` |The template used to render the page. If not provided, the `Site`'s `content`will be used. |
 | `Parser` | `type[BasePageParser]` |The parser to generate the page's `raw_content`. Defaults to `BasePageParser`. |
 | `title` | `str` |The title of the page. Defaults to the class name. |
+| `skip_site_map`    | `False` | When set to `True` the `Page` will not be included in the generated `SiteMap` |
 
 ## About Page Attributes
 
@@ -103,3 +105,19 @@ By default Page._content will return the result of `Page.Parser.parse(Page.conte
 ### Page Templates
 
 `Page.template` should always be a `str`. `Page.template` refers to the template name that will be passed to the engine given to `Page.render()`.
+
+### Accessing URLs for other pages in the site from within the page content
+
+In order to allow lookup of URLs for other pages within a Site the `content` of a page may be
+a template. If the `content` matches the pattern `{{.*?}}` we will render the `content` as a
+template prior to rendering the page itself.
+
+Example:
+
+```
+{{ site_map.find('my_page').url_for }}
+```
+
+will render to the URL for `my_page` in the `content` and then in the generated page.
+
+For more details on using the `SiteMap` please check the [SiteMap documentation](site_map.md).

--- a/docs/docs/site_map.md
+++ b/docs/docs/site_map.md
@@ -1,0 +1,70 @@
+---
+title: "SiteMap Objects"
+description: "Overview of the SiteMap"
+date: September 27, 2025
+tags: ["site-map"]
+---
+Prior to rendering the `Site` Render Engine will create a `SiteMap` containing searchable information
+about all of the `Collection` and `Page` objects it has.
+
+## Searching the `SiteMap`
+
+To search the `SiteMap` use the `find` method.
+
+```python
+    def find(
+        self,
+        value: str,
+        attr: str = "slug",
+        collection: str = None,
+        full_search: bool = False,
+    ) -> SiteMapEntry | None:
+```
+
+### Parameters
+
+- `value`: The value to search for
+- `attr`: Optional attribute to search by. Options are `slug`, `title`, `path_name`. Defaults to `slug`.
+- `collection`: Limit the search to a single `Collection`. Defaults to `None`.
+- `full_search`: Search all `Page` and `Collection` objects. Defaults to `False`.
+
+Notes:
+
+1. If `collection` is set the search will be limited to that `Collection` object regardless of whether
+`full_search` is set.
+2. If `full_search` is set it will return the first match found. If you have 3 pages with the same `slug`,
+1 not in a `Collection` and 2 others in different `Collection` objects, the first one defined will be the
+one found.
+
+## Generating an HTML site map
+
+The `SiteMap` object has an `html` property that will return an HTML sitemap with _absolute_ URLs with the
+`Site`'s `SITE_URL`.
+
+As a convenience, Render Engine will generate a site map page if the `Site` property of `render_site_map`
+is `True` (it defaults to `False`.) Please note that this will not be templated. Should you wish the generated
+site map to be on a template you can add the following to your app:
+
+```python
+@app.page
+class SiteMapPage(Page):
+    template = "site_map_template.html"
+    content = "{{ site_map.html }}"
+    skip_site_map = True
+```
+
+Please note the `skip_site_map = True` to avoid having a self referential link to the site map.
+
+## The `SiteMapEntry` object
+
+The `SiteMap` is a collection of `SiteMapEntry` objects. Each `SiteMapEntry` has the following attributes
+and properties:
+
+### Attributes and Properties
+
+- `slug` - The `slug` for the referenced `Page` or `Collection`.
+- `title` - The `title` for the referenced `Page` or `Collection`.
+- `path_name` - The `path_name` for the referenced `Page` or `Collection`.
+- `entries` - A list of `SiteMapEntry` objects representing the `Page` objects in a given `Collection`.
+for a `Page` this will be an empty `list`.
+- `url_for` - This property will provide the _relative_ URL for the given entry.

--- a/src/render_engine/_base_object.py
+++ b/src/render_engine/_base_object.py
@@ -26,6 +26,7 @@ class BaseObject:
     template_vars: dict
     plugins: list[Callable] | None
     plugin_settings: dict = {"plugins": defaultdict(dict)}
+    skip_site_map: bool = False
 
     @property
     def _title(self) -> str:

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -86,6 +86,10 @@ class Site:
     def static_paths(self, static_paths: set) -> None:
         self.theme_manager.static_paths = static_paths
 
+    @property
+    def site_map(self) -> SiteMap:
+        return self._site_map
+
     def update_site_vars(self, **kwargs) -> None:
         self.site_vars.update(**kwargs)
         self.theme_manager.engine.globals.update(self.site_vars)
@@ -249,7 +253,6 @@ class Site:
         with Progress() as progress:
             task_site_map = progress.add_task("Generating site map", total=1)
             self._site_map = SiteMap(self.route_list, self.site_vars.get("SITE_URL", ""))
-            self.site_vars["SITE_MAP"] = self._site_map
             if self.render_site_map:
 
                 @self.page

--- a/src/render_engine/site_map.py
+++ b/src/render_engine/site_map.py
@@ -28,7 +28,6 @@ class SiteMapEntry:
                 ]
             case _:
                 pass
-        print(self._route)
 
     @property
     def url_for(self) -> str:
@@ -57,8 +56,8 @@ class SiteMap:
 
     def find(
         self,
-        attr: str,
         value: str,
+        attr: str = "slug",
         collection: str = None,
         full_search: bool = False,
     ) -> SiteMapEntry | None:
@@ -70,8 +69,8 @@ class SiteMap:
         will be searched if full_search is True.
         If there would be a match in multiple collections - or for just a page, the first match will be returned.
 
-        :param attr: The name of attribute to search for
         :param value: The value of attribute to search for
+        :param attr: The name of attribute to search for, defaults to slug
         :param collection: The name of the collection to search
         :param full_search: Search recursively in collections
         :return: The first found match or None if not found
@@ -91,6 +90,8 @@ class SiteMap:
                     return s_entry
             return None
 
+        if not value:
+            return None
         if collection:
             # Collection was specified so check there
             return (

--- a/src/render_engine/site_map.py
+++ b/src/render_engine/site_map.py
@@ -47,7 +47,11 @@ class SiteMap:
         """
         self._route_map = dict()
         self._collections = dict()
+        route: str
+        entry: BaseObject
         for route, entry in route_list.items():
+            if entry.skip_site_map:
+                continue
             sm_entry = SiteMapEntry(entry, route)
             self._route_map[sm_entry.slug] = sm_entry
             if sm_entry.entries:

--- a/tests/test_site_map.py
+++ b/tests/test_site_map.py
@@ -13,27 +13,47 @@ title: {title}
 slug: {slug}
 ---
 {title}
+{url}
 """
 
 
 @pytest.fixture(scope="module")
 def site(tmp_path_factory):
-    tmp_output_path = tmp_path_factory.getbasetemp() / "test_output"
-    tmp_input_path = tmp_path_factory.getbasetemp() / "content"
+    base_temp_path = tmp_path_factory.getbasetemp()
+    tmp_output_path = base_temp_path / "test_output"
+    tmp_input_path = base_temp_path / "content"
     tmp_input_path.mkdir(parents=True)
+    tmp_template_path = base_temp_path / "templates"
+    tmp_template_path.mkdir(parents=True)
+    template_file_name = "template_file.html"
+    template_file = tmp_template_path / template_file_name
+    template_file.write_text("{{ content }}\n")
 
     coll_pages = defaultdict(list)
     for collection in ["coll1", "coll2"]:
         for n in range(4):
             coll_pages[collection].append(
-                Page(content=PAGE_TEMPLATE.format(title=f"{collection} -- Page {n}", slug=f"page{n}"))
+                Page(
+                    content=PAGE_TEMPLATE.format(
+                        title=f"{collection} -- Page {n}",
+                        slug=f"page{n}",
+                        url="{{ site_map.find('page0', collection='coll1').url_for }}",
+                    )
+                )
             )
     for n in range(3):
         content_file = tmp_input_path / f"page{n}.md"
-        content_file.write_text(PAGE_TEMPLATE.format(title=f"Page {n}", slug=f"page{n}"))
+        content_file.write_text(
+            PAGE_TEMPLATE.format(
+                title=f"Page {n}",
+                slug=f"page{n}",
+                url="{{ site_map.find('page0', collection='coll1').url_for }}",
+            )
+        )
 
     class testSite(Site):
         output_path = tmp_output_path
+        _template_path = tmp_template_path
 
     site = testSite()
 
@@ -52,6 +72,7 @@ def site(tmp_path_factory):
         @site.page
         class MyPage(Page):
             content_path = tmp_input_path / f"page{n}.md"
+            template = template_file_name
 
     yield site
 
@@ -82,31 +103,37 @@ def test_site_map_to_html(site):
 
 
 @pytest.mark.parametrize(
-    "attr, value, params, expected",
+    "value, params, expected",
     [
-        ("slug", "page1", {}, "/page1.html"),
-        ("slug", "page3", {}, None),
-        ("slug", "page3", {"full_search": True}, "/coll1/page3.html"),
-        ("slug", "page3", {"collection": "coll2"}, "/coll2/page3.html"),
-        ("path_name", "page1.html", {}, "/page1.html"),
-        ("path_name", "page3.html", {}, None),
-        ("path_name", "page3.html", {"full_search": True}, "/coll1/page3.html"),
-        ("path_name", "page3.html", {"collection": "coll2"}, "/coll2/page3.html"),
-        ("slug", "page1", {}, "/page1.html"),
-        ("slug", "page3", {}, None),
-        ("slug", "page3", {"full_search": True}, "/coll1/page3.html"),
-        ("slug", "page3", {"collection": "coll2"}, "/coll2/page3.html"),
-        ("title", "Page 1", {}, "/page1.html"),
-        ("title", "coll1 -- Page 3", {}, None),
-        ("title", "coll1 -- Page 3", {"full_search": True}, "/coll1/page3.html"),
-        ("title", "coll1 -- Page 3", {"collection": "coll2"}, None),
-        ("title", "coll2 -- Page 3", {"collection": "coll2"}, "/coll2/page3.html"),
+        ("page1", {}, "/page1.html"),
+        ("page1", {"attr": "slug"}, "/page1.html"),
+        ("page3", {"attr": "slug"}, None),
+        ("page3", {"attr": "slug", "full_search": True}, "/coll1/page3.html"),
+        ("page3", {"attr": "slug", "collection": "coll2"}, "/coll2/page3.html"),
+        ("page1.html", {"attr": "path_name"}, "/page1.html"),
+        ("page3.html", {"attr": "path_name"}, None),
+        ("page3.html", {"attr": "path_name", "full_search": True}, "/coll1/page3.html"),
+        ("page3.html", {"attr": "path_name", "collection": "coll2"}, "/coll2/page3.html"),
+        ("page1", {"attr": "slug"}, "/page1.html"),
+        ("page3", {"attr": "slug"}, None),
+        ("page3", {"attr": "slug", "full_search": True}, "/coll1/page3.html"),
+        ("page3", {"attr": "slug", "collection": "coll2"}, "/coll2/page3.html"),
+        ("Page 1", {"attr": "title"}, "/page1.html"),
+        ("coll1 -- Page 3", {"attr": "title"}, None),
+        ("coll1 -- Page 3", {"attr": "title", "full_search": True}, "/coll1/page3.html"),
+        ("coll1 -- Page 3", {"attr": "title", "collection": "coll2"}, None),
+        ("coll2 -- Page 3", {"attr": "title", "collection": "coll2"}, "/coll2/page3.html"),
     ],
 )
-def test_site_map_search(site, attr, value, params, expected):
+def test_site_map_search(site, value, params, expected):
     sm = SiteMap(site.route_list, "")
     if expected is not None:
-        found = sm.find(attr, value, **params)
+        found = sm.find(value, **params)
         assert found.url_for == expected
     else:
-        assert sm.find(attr, value, **params) is None
+        assert sm.find(value, **params) is None
+
+
+def test_find_in_template(site):
+    site.render()
+    assert (site.output_path / "page1.html").read_text() == "Page 1\n/coll1/page0.html"

--- a/tests/test_site_map.py
+++ b/tests/test_site_map.py
@@ -41,7 +41,7 @@ def site(tmp_path_factory):
                     )
                 )
             )
-    for n in range(3):
+    for n in range(4):
         content_file = tmp_input_path / f"page{n}.md"
         content_file.write_text(
             PAGE_TEMPLATE.format(
@@ -67,12 +67,13 @@ def site(tmp_path_factory):
         collection_class.__name__ = collection
         site.collection(collection_class)
 
-    for n in range(3):
+    for n in range(4):
 
         @site.page
         class MyPage(Page):
             content_path = tmp_input_path / f"page{n}.md"
             template = template_file_name
+            skip_site_map = n == 3
 
     yield site
 


### PR DESCRIPTION
- Resolves #47
- Fixes some minor issues with searching the `SiteMap`
- Pre-renders `Page` content when the pattern `{{.*}}` is found in the content.
- Adds ability to not include a given `Page`/`Collection` in the `SiteMap`
- Documents the `SiteMap` functionality.

#### Type of Issue

- [ ] :bug: (bug)
- [x] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [x] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [x] YES - Changes have been documented

#### Changes have been Tested

- [x] YES - Changes have been tested

#### Next Steps

