### PR TITLE
Update Ruff target version to Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ branch = "main"
 [tool.ruff]
 line-length = 120
 indent-width = 4
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]


### PR DESCRIPTION
Closes #1246.

Updates Ruff's configured target from Python 3.10 to Python 3.11 so its version-aware checks and autofixes match the minimum version exercised by this release branch.

The stale `py310` setting prevented the enabled `UP` rules from reporting Python 3.11 upgrades. This is a tooling configuration change only; it does not change runtime behavior or dependencies.

This PR intentionally does not apply the resulting `datetime.UTC` cleanup because that work is separately assigned in #1249. It should be rebased and marked ready after #1249 lands on this branch.

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [x] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [x] YES - Changes have been documented (not applicable beyond this configuration and PR description)

#### Changes have been Tested

- [x] YES - Changes have been tested

Validation:

- `uvx nox` — all Python 3.11, 3.12, 3.13, 3.14, and 3.15 sessions passed; each ran 159 passing tests with 1 skip
- `uvx ruff format --check .` — passed (40 files already formatted)
- `uv run ty check src/render_engine` — passed
- `uv lock --check` — passed
- `git diff --check` — passed
- `uvx ruff check .` — expected `UP017` in `tests/test_feeds/test_feeds.py:82`, tracked and separately assigned in #1249

#### Next Steps

- Merge the `datetime.UTC` cleanup from #1249 into `remove-3.10-python-3.15-release`.
- Rebase this branch, rerun Ruff, and mark this PR ready for review.

#### AI Attestation

OpenAI Codex assisted with repository and issue analysis, the scoped configuration edit, validation, and preparation of this draft PR. I reviewed the change and remain responsible for the submission. Codex is included as a co-author on the commit.
