### PR TITLE
docs: update supported python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ## Installing Render Engine
 
-To use the render engine, you must have Python 3.10 or greater installed. You can download Python from [python.org].
+To use the render engine, you must have Python 3.10 or greater (supporting Python 3.10, 3.11, 3.12, 3.13, 3.14, and 3.15) installed. You can download Python from [python.org].
 
 - Linux/MacOS: [python.org]
 - Windows: Install Python using [pymanager on Microsoft Store][ms-store], which manages Python installations.

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -5,7 +5,7 @@ date: August 22, 2024
 tags: ["installation", "render-engine"]
 ---
 
-To use the render engine, you must have Python 3.10 or greater installed. You can download Python from [python.org].
+To use the render engine, you must have Python 3.10 or greater (supporting Python 3.10, 3.11, 3.12, 3.13, 3.14, and 3.15) installed. You can download Python from [python.org].
 
 - Linux/MacOS: [python.org]
 - Windows: Install Python using [pymanager on Microsoft Store][ms-store], which manages Python installations.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -16,7 +16,7 @@ tags:
 
 ### Installing Render Engine
 
-To use the render engine, you must have Python 3.10 or greater installed. You can download Python from [python.org].
+To use the render engine, you must have Python 3.10 or greater (supporting Python 3.10, 3.11, 3.12, 3.13, 3.14, and 3.15) installed. You can download Python from [python.org].
 
 - Linux/MacOS: [python.org]
 - Windows: Install Python using [pymanager on Microsoft Store][ms-store], which manages Python installations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,14 @@ dynamic = ["version"]
 description = "A Flexible Static Site Generator for Python"
 readme = "README.md"
 requires-python = ">=3.10"
+classifiers = [
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
+]
 dependencies = [
   "jinja2==3.1.6",
   "more-itertools==11.1.0",


### PR DESCRIPTION
Fixes #1247

This PR explicitly lists the supported Python versions in `README.md` and `docs/`, and adds classifiers in `pyproject.toml` to reflect that Python 3.10 through 3.15 are supported.