### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/docs/docs/contributing/CONTRIBUTING.md
+++ b/docs/docs/contributing/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Render Engine
 
-While the Render Engine team welcomes contributions to our repositories we do ask that only humans contribute to them.
+While the Render Engine team welcomes contributions to [our repositories] we do ask that only humans contribute to them.
 This does not mean that humans are not permitted to use LLMs in the course of their contributions, however any
 contributions from accounts that are not owned by a human will be rejected immediately.
 
@@ -162,3 +162,4 @@ Multiple low quality contributions will result in your user account being banned
 [Wait to be assigned an issue]: #wait-to-be-assigned-issues
 [Formatting your PR]: #formatting-your-pr
 [issue in GitHub]: https://github.com/render-engine/render-engine/issues/new/choose
+[our repositories]: https://github.com/render-engine

--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ nox:
 
 docs port="8000":
     @echo "Starting documentation server on port {{port}}..."
-    mkdocs serve -f docs/mkdocs.yml -a 0.0.0.0:{{port}}
+    uv run --group docs mkdocs serve -f docs/mkdocs.yml -a 0.0.0.0:{{port}}
 
 # Run markdown linter (requires bun or npm)
 lint-md *DIRECTORY="*.md docs/**/*.md":  # Note that we don't want the ** glob from root because that will include site packages


### PR DESCRIPTION
Resolves #1258 

- Adds link to [Render Engine GitHub home](https://github.com/render-engine) to `CONTRIBUTING.md`
- Updates `docs` recipe in the justfile to ensure that the `docs` group is installed when run

#### Type of Issue

- [ ] :bug: (bug)
- [X] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [X] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps

None

#### AI Attestation

No AI was used.